### PR TITLE
Loaded system config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /python/python.pyproj
 /python/python.sln
 
+.config_files
 config_files/*.conf
 !config_files/sppconnections_default.conf

--- a/python/influx/definitions.py
+++ b/python/influx/definitions.py
@@ -294,7 +294,7 @@ class Definitions:
             name='jobs',
             fields={  # FIELDS
                 'duration':         Datatype.INT,
-                'start':            Datatype.TIMESTAMP, 
+                'start':            Datatype.TIMESTAMP,
                 'end':              Datatype.TIMESTAMP,
                 'jobLogsCount':     Datatype.INT,
                 'id':               Datatype.INT
@@ -418,7 +418,8 @@ class Definitions:
                 "transfer_data",
                 "old_database",
                 "create_dashboard",
-                "dashboard_folder_path"
+                "dashboard_folder_path",
+                "loadedSystem"
             ],
             retention_policy=cls._RP_DAYS_14(),
             continuous_queries=[
@@ -487,7 +488,7 @@ class Definitions:
                         "mean(cpu) as cpu",
                         "mean(coresPerCpu) as coresPerCpu",
                         "mean(memory) as memory"
-                    ], 
+                    ],
                     new_retention_policy=cls._RP_DAYS_90(),
                     group_time="6h",
                     group_args=[

--- a/python/sppConnection/rest_client.py
+++ b/python/sppConnection/rest_client.py
@@ -41,17 +41,23 @@ class RestClient():
         'Content-type': 'application/json'}
     """Headers send to the REST-API. SessionId added after login."""
 
-    def __init__(self, auth_rest: Dict[str, Any], timeout: int, preferred_time: float,
-                 page_size: int, min_page_size: int, send_retries: int, verbose: bool):
+    def __init__(self, auth_rest: Dict[str, Any],
+                 pref_send_time: int,
+                 request_timeout: int,
+                 send_retries: int,
+                 starting_page_size: int,
+                 min_page_size: int,
+
+                 verbose: bool):
 
         if(not auth_rest):
             raise ValueError("REST API parameters are not specified")
-        if(timeout is None):
+        if(request_timeout is None):
             raise ValueError("no timeout specified")
-        self.__timeout = timeout
+        self.__timeout = request_timeout
 
-        self.__preferred_time = preferred_time
-        self.__page_size = page_size
+        self.__preferred_time = pref_send_time
+        self.__page_size = starting_page_size
         self.__min_page_size = min_page_size
         self.__send_retries = send_retries
 

--- a/python/sppConnection/rest_client.py
+++ b/python/sppConnection/rest_client.py
@@ -47,7 +47,6 @@ class RestClient():
                  send_retries: int,
                  starting_page_size: int,
                  min_page_size: int,
-
                  verbose: bool):
 
         if(not auth_rest):
@@ -107,9 +106,6 @@ class RestClient():
             LOGGER.info(f"SPP-Version: {version}, build {build}")
 
         self.__headers['X-Endeavour-Sessionid'] = self.__sessionid
-
-
-
 
 
     def logout(self) -> None:

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -168,8 +168,8 @@ class SppMon:
 
     # ## Recommend changes for loaded systems ##
 
-    # Use --loaded_systems if sppmon causes big CPU spikes on your SPP-Server
-    # CAUTION: using --loaded_systems causes some data to not be recorded.
+    # Use --loadedSystem if sppmon causes big CPU spikes on your SPP-Server
+    # CAUTION: using --loadedSystem causes some data to not be recorded.
     # all changes adjusts settings to avoid double running mongodb jobs.
     # Hint: make sure SPP-mongodb tables are correctly indexed.
 
@@ -185,7 +185,7 @@ class SppMon:
     # Critical/Big Spikes:
 
     # CAUTION DATALOSS: causes only SUMMARY-Joblogs to be recorded
-    # 1. Enable `--loaded_systems`
+    # 1. Enable `--loadedSystem`
     # 2. finetune `loaded`-variables (see medium spikes 1-3)
 
     # Other finetuning mechanics (no data-loss):
@@ -556,7 +556,7 @@ class SppMon:
 
         if(OPTIONS.minimumLogs):
             ExceptionUtils.error_message(
-                "DEPRICATED: using depricated argument '--minumumLogs'. Switch to '--loadedSystems'.")
+                "DEPRICATED: using depricated argument '--minumumLogs'. Switch to '--loadedSystem'.")
 
         # incremental setup, higher executes all below
         all_args: bool = OPTIONS.all

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -40,6 +40,7 @@ Author:
  08/02/2020 version 0.10.0 Introducing Retention Policies and Continuous Queries, breaking old tables
  08/25/2020 version 0.10.1 Fixes to Transfer Data, Parse Unit and Top-SSH-Command parsing
  09/01/2020 version 0.10.2 Parse_Unit fixes (JobLogs) and adjustments on timeout
+ 11/10/2020 version 0.10.3 Introduced --loadedSystem argument and moved --minimumLogs to depricated
 
 """
 from __future__ import annotations
@@ -69,7 +70,7 @@ from utils.methods_utils import MethodUtils
 from utils.spp_utils import SppUtils
 
 # Version:
-VERSION = "0.10.2  (2020/09/01)"
+VERSION = "0.10.3  (2020/11/10)"
 
 # ----------------------------------------------------------------------------
 # command line parameter parsing
@@ -94,8 +95,8 @@ parser.add_option("--all", dest="all", action="store_true", help="execute all fu
 parser.add_option("--jobs", dest="jobs", action="store_true", help="store job history")
 parser.add_option("--jobLogs", dest="jobLogs", action="store_true",
                   help="retrieve detailed information per job (job-sessions)")
-parser.add_option("--minimumLogs", dest="minimumLogs", action="store_true",
-                  help="only with --joblogs/daily/all: special settings for loaded systems")
+parser.add_option("--loadedSystem", dest="loadedSystem", action="store_true",
+                  help="Special settings for loaded systems, reducing API-request loads")
 
 parser.add_option("--ssh", dest="ssh", action="store_true", help="execute monitoring commands via ssh")
 parser.add_option("--processStats", dest="processStats", action="store_true",
@@ -113,6 +114,9 @@ parser.add_option("--cpu", dest="cpu", action="store_true", help="capture SPP se
 parser.add_option("--sppcatalog", dest="sppcatalog", action="store_true", help="capture Spp-Catalog Storage usage")
 
 ##########################
+#TODO Remove minimum Logs on next version.
+parser.add_option("--minimumLogs", dest="minimumLogs", action="store_true",
+                  help="DEPRICATED, use '--loadedSystem' instead")
 parser.add_option("--transfer_data", dest="transfer_data", action="store_true",
                   help="TEMPORARY FEATURE:transfer data into retention policies, BACKUP before doing so")
 parser.add_option("--old_database", dest="old_database",
@@ -157,36 +161,71 @@ class SppMon:
     MethodUtils.verbose = OPTIONS.verbose
     SppUtils.verbose = OPTIONS.verbose
 
-    # ## API-REST Page settings ## #
-    timeout_reduction = 0.9
-    """How much % the pagesize is reduced after a timeout"""
-    allowed_time_diff_quota = 0.1
-    """% allowed to differ before adjustments are made"""
-    maximum_increase_pagesize = 3.5
-    """maximum factor for the pagesize to be increased in one go"""
-    page_size = 50
-    """ the starting page size, adjusted later on within rest_client"""
-    min_page_size = 1
-    """minimum size of a rest-api page"""
+    # ###### API-REST page settings  ###### #
+    # ## IMPORTANT NOTES ## #
+    # please read the documentation before adjusting values.
+    # if unsure contact the sppmon develop team before adjusting
+
+    # ## Recommend changes for loaded systems ##
+    # CAUTION: using --loaded_systems causes some data to not be recorded.
+    # Changes: Adjusts settings to avoid double running jobs.
+    # Hint: make sure SPP-Mongod tables are correctly indexed.
+
+    # Priority list for manual changes:
+    # (0. decrease allowed_send_delta)
+    # 1. increase timeout while decreasing preferred send time
+    # 2. decrease scaling factor (>1)
+    # 3. increase timeout reduction (0-0.99)
+    # 4. decrease starting pagesize (>1)
+    # CAUTION DATALOSS below: not all data is recorded
+    # 5. set joblog_type on "Summary" only
+    # 6. reduce retries (0 = disable)
+
+    preferred_send_time = 30
+    """preferred query send time in seconds"""
+    loaded_preferred_time = 20
+    """desired send time per query in seconds for loaded systems"""
+
+    max_scaling_factor = 3.5
+    """max scaling factor of the pagesize increase per request"""
+    loaded_max_scaling_factor = 3.5
+    """max scaling factor of the pagesize increase per request for loaded systems"""
+
+    allowed_send_delta = 0.1
+    """delta of send allowed before adjustments are made in %"""
+    loaded_allowed_send_delta = 0.1
+    """delta of send allowed before adjustments are made in % on loaded systems"""
+
+    request_timeout = 60
+    """timeout for api-requests"""
+    loaded_request_timeout = 360
+    """timeout on loaded systems"""
+
+    timeout_reduction = 0.7
+    """reduce of the actual pagesize on timeout in percent"""
+    loaded_timeout_reduction = 0.95
+    """reduce of the actual pagesize on timeout in percent on loaded systems"""
+
     send_retries = 3
-    """How much retries are made before failing, last one is on min-size"""
+    """Count of retries before failing request. Last one is min size. 0 to disable."""
+    loaded_send_retries = 1
+    """Count of retries before failing request on loaded systems. Last one is min size. 0 to disable."""
 
+    starting_page_size = 50
+    """starting page size for dynamical change within rest_client"""
+    loaded_starting_page_size = 10
+    """starting page size for dynamical change within rest_client on loaded systems"""
 
-    # minimum settings
-    loaded_preferred_time = 40
-    """perfect query send time in seconds for loaded systems"""
-    minimum_timeout = 90
-    """increased timeout on loaded systems."""
-    minLogs_joblog_type = '["SUMMARY"]'
-    """reduced types to be requested on loaded systems."""
+    min_page_size = 5
+    """minimum size of a rest-api page"""
+    loaded_min_page_size = 1
+    """minimum size of a rest-api page on loaded systems"""
 
-    # default settings
-    default_joblog_type = '["INFO","DEBUG","ERROR","SUMMARY","WARN"]'
+    # possible options: '["INFO","DEBUG","ERROR","SUMMARY","WARN"]'
+    joblog_types = '["INFO","DEBUG","ERROR","SUMMARY","WARN"]'
     """regular joblog query types on normal running systems"""
-    default_timeout = 60
-    """regular timeout on normal running systems"""
-    preferred_time = 30
-    """perfect query send time in seconds"""
+    loaded_joblog_types = '["SUMMARY"]'
+    """jobLog types to be requested on loaded systems."""
 
     # set later in each method, here to avoid missing attribute
     influx_client = None
@@ -393,18 +432,18 @@ class SppMon:
 
             ConnectionUtils.verbose = OPTIONS.verbose
             ConnectionUtils.timeout_reduction = self.timeout_reduction
-            ConnectionUtils.allowed_time_diff_quota = self.allowed_time_diff_quota
-            ConnectionUtils.maximum_increase_pagesize = self.maximum_increase_pagesize
+            ConnectionUtils.allowed_time_diff_quota = self.allowed_send_delta
+            ConnectionUtils.maximum_increase_pagesize = self.max_scaling_factor
 
 
             if(OPTIONS.minimumLogs):
-                rest_time_out = self.minimum_timeout
+                rest_time_out = self.loaded_request_timeout
                 rest_preferred_time = self.loaded_preferred_time
             else:
-                rest_time_out = self.default_timeout
-                rest_preferred_time = self.preferred_time
+                rest_time_out = self.request_timeout
+                rest_preferred_time = self.preferred_send_time
 
-            self.rest_client = RestClient(auth_rest, rest_time_out, rest_preferred_time, self.page_size,
+            self.rest_client = RestClient(auth_rest, rest_time_out, rest_preferred_time, self.starting_page_size,
                                           self.min_page_size, self.send_retries, OPTIONS.verbose)
 
             self.api_queries = ApiQueries(self.rest_client)
@@ -425,8 +464,8 @@ class SppMon:
         try:
             self.job_methods = JobMethods(
                 self.influx_client, self.api_queries, self.job_log_retention_time,
-                self.minLogs_joblog_type,
-                self.default_joblog_type,
+                self.loaded_joblog_types,
+                self.joblog_types,
                 OPTIONS.verbose, OPTIONS.minimumLogs)
         except ValueError as error:
             ExceptionUtils.exception_info(error=error)

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -167,19 +167,31 @@ class SppMon:
     # if unsure contact the sppmon develop team before adjusting
 
     # ## Recommend changes for loaded systems ##
+
+    # Use --loaded_systems if sppmon causes big CPU spikes on your SPP-Server
     # CAUTION: using --loaded_systems causes some data to not be recorded.
-    # Changes: Adjusts settings to avoid double running jobs.
-    # Hint: make sure SPP-Mongod tables are correctly indexed.
+    # all changes adjusts settings to avoid double running mongodb jobs.
+    # Hint: make sure SPP-mongodb tables are correctly indexed.
 
     # Priority list for manual changes:
-    # (0. decrease allowed_send_delta)
+
+    # Small/Medium Spikes:
+
+    # finetune `default` variables:
     # 1. increase timeout while decreasing preferred send time
-    # 2. decrease scaling factor (>1)
-    # 3. increase timeout reduction (0-0.99)
-    # 4. decrease starting pagesize (>1)
-    # CAUTION DATALOSS below: not all data is recorded
-    # 5. set joblog_type on "Summary" only
-    # 6. reduce retries (0 = disable)
+    # 2. increase timeout reduction (0-0.99)
+    # 3. decrease scaling factor (>1)
+
+    # Critical/Big Spikes:
+
+    # CAUTION DATALOSS: causes only SUMMARY-Joblogs to be recorded
+    # 1. Enable `--loaded_systems`
+    # 2. finetune `loaded`-variables (see medium spikes 1-3)
+
+    # Other finetuning mechanics (no data-loss):
+    # 1. decrease allowed_send_delta (>=0)
+    # 2. decrease starting pagesize (>1)
+
 
     pref_send_time: int = 30
     """preferred query send time in seconds"""
@@ -192,9 +204,9 @@ class SppMon:
     """max scaling factor of the pagesize increase per request for loaded systems"""
 
     allowed_send_delta: float = 0.1
-    """delta of send allowed before adjustments are made in %"""
+    """delta of send allowed before adjustments are made to the pagesize in %"""
     loaded_allowed_send_delta: float = 0.1
-    """delta of send allowed before adjustments are made in % on loaded systems"""
+    """delta of send allowed before adjustments are made to the pagesize in % on loaded systems"""
 
     request_timeout: int = 60
     """timeout for api-requests"""

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -184,9 +184,10 @@ class SppMon:
 
     # Critical/Big Spikes:
 
-    # CAUTION DATALOSS: causes only SUMMARY-Joblogs to be recorded
+    # CAUTION Reduce Recording: causes less Joblogs-Types to be recorded
     # 1. Enable `--loadedSystem`
     # 2. finetune `loaded`-variables (see medium spikes 1-3)
+    # 3. Reduce JobLog-Types (min only `SUMMARY`)
 
     # Other finetuning mechanics (no data-loss):
     # 1. decrease allowed_send_delta (>=0)
@@ -236,7 +237,7 @@ class SppMon:
     # possible options: '["INFO","DEBUG","ERROR","SUMMARY","WARN"]'
     joblog_types: str = '["INFO","DEBUG","ERROR","SUMMARY","WARN"]'
     """regular joblog query types on normal running systems"""
-    loaded_joblog_types: str = '["SUMMARY"]'
+    loaded_joblog_types: str = '["DEBUG","ERROR","SUMMARY","WARN"]'
     """jobLog types to be requested on loaded systems."""
 
     # String, cause of days etc

--- a/python/sppmonMethods/jobs.py
+++ b/python/sppmonMethods/jobs.py
@@ -94,8 +94,7 @@ class JobMethods:
     """LogLog messageID's which can be parsed by sppmon. Check detailed summary above the declaration."""
 
     def __init__(self, influx_client: Optional[InfluxClient], api_queries: Optional[ApiQueries],
-                 job_log_retention_time: str, minLogs_joblog_type: str,
-                 default_joblog_type: str, verbose: bool, minimum_logs: bool):
+                 job_log_retention_time: str, job_log_type: str, verbose: bool):
 
         if(not influx_client):
             raise ValueError("Job Methods are not available, missing influx_client")
@@ -105,13 +104,11 @@ class JobMethods:
         self.__influx_client = influx_client
         self.__api_queries = api_queries
         self.__verbose = verbose
-        self.__minimum_logs = minimum_logs
 
         self.__job_log_retention_time = job_log_retention_time
         """used to limit the time jobLogs are queried, only interestig for init call"""
 
-        self.__min_logs_joblog_type = minLogs_joblog_type
-        self.__default_joblog_type = default_joblog_type
+        self.__job_log_type = job_log_type
 
     def get_all_jobs(self) -> None:
         """incrementally saves all stored jobsessions, even before first execution of sppmon"""
@@ -320,13 +317,6 @@ class JobMethods:
 
         job_log_dict: Dict[int, List[Dict[str, Any]]] = {}
 
-        if(self.__minimum_logs):
-            job_logs_type = self.__min_logs_joblog_type
-            LOGGER.debug("Using minimum Logs")
-        else:
-            job_logs_type = self.__default_joblog_type
-
-
         # request all jobLogs from REST-API
         # if errors occur, skip single row and debug
         for row in result_list:
@@ -351,13 +341,13 @@ class JobMethods:
             # request job_session_id
             try:
                 if(self.__verbose):
-                    LOGGER.info(f"requesting jobLogs {job_logs_type} for session {job_session_id}.")
-                LOGGER.debug(f"requesting jobLogs {job_logs_type} for session {job_session_id}.")
+                    LOGGER.info(f"requesting jobLogs {self.__job_log_type} for session {job_session_id}.")
+                LOGGER.debug(f"requesting jobLogs {self.__job_log_type} for session {job_session_id}.")
 
                 # cant use query something like everwhere due the extra params needed
                 job_log_list = self.__api_queries.get_job_log_details(
                     jobsession_id=job_session_id,
-                    job_logs_type=job_logs_type)
+                    job_logs_type=self.__job_log_type)
             except ValueError as error:
                 ExceptionUtils.exception_info(
                     error=error,

--- a/python/utils/connection_utils.py
+++ b/python/utils/connection_utils.py
@@ -26,11 +26,11 @@ class ConnectionUtils:
 
     """
 
-    allowed_time_diff_quota: float
+    allowed_send_delta: float
     """How much % difference is allowed in both directions before adjustments are made"""
     timeout_reduction: float
     """How much % the pagesize is reduced after a timeout"""
-    maximum_increase_pagesize: float
+    max_scaling_factor: float
     """maximum factor for the pagesize to be increased in one go"""
     verbose = False
 
@@ -212,7 +212,7 @@ class ConnectionUtils:
 
         time_difference_quota = send_time / preferred_time
 
-        if(abs(time_difference_quota-1) > cls.allowed_time_diff_quota):
+        if(abs(time_difference_quota-1) > cls.allowed_send_delta):
             LOGGER.debug(f"adjusting page size due too high time difference, actual: {send_time}, preferred: {preferred_time}")
             if(cls.verbose):
                 LOGGER.info(f"adjusting page size due too high time difference, actual: {send_time}, preferred: {preferred_time}")
@@ -222,8 +222,8 @@ class ConnectionUtils:
             new_page_size = int(new_page_size)
 
             # limit the maximum grow, with bonus for very low areas
-            if(new_page_size > cls.maximum_increase_pagesize * (page_size + 5)):
-                new_page_size = int(cls.maximum_increase_pagesize * (page_size + 5))
+            if(new_page_size > cls.max_scaling_factor * (page_size + 5)):
+                new_page_size = int(cls.max_scaling_factor * (page_size + 5))
 
             # avoid getting stuck on 1
             if(new_page_size < min_page_size + 5):


### PR DESCRIPTION
I split up all rest-api configs into loaded and default systems. Also i moved all important settings into one place at the sppmon.py file, as well as giving a small disclaimer. 

I've labled the argument `--minimumLogs` as depricated and introduced the new arg `--loadedSystems`. This new arg-group should make the new settings more understandable. 
I'd like to remove `--minimumLogs` within the next version (or the release). For now, both args do exactly the same to not break running systems.

@baslerj Please test it in your own enviroment. I think I've already set up appropriate settings, but you might need to finetune some settings. Those changes might be a good recommendation for other loaded systems.