### PR TITLE
Replacement of ssh 'top' command

### DIFF
--- a/python/influx/definitions.py
+++ b/python/influx/definitions.py
@@ -971,18 +971,13 @@ class Definitions:
             fields={
                 '%CPU':                     Datatype.FLOAT,
                 '%MEM':                     Datatype.FLOAT,
-                'RES':                      Datatype.INT, #TODO DELETE
-                'SHR':                      Datatype.INT, #TODO DELETE
                 'TIME+':                    Datatype.INT,
                 'VIRT':                     Datatype.INT,
                 'MEM_ABS':                  Datatype.INT
             },
             tags=[
                 'COMMAND',
-                'NI',  #TODO DELETE
                 'PID',
-                'PR',  #TODO DELETE
-                'S',  #TODO DELETE
                 'USER',
                 'hostName',
                 'ssh_type'

--- a/python/influx/definitions.py
+++ b/python/influx/definitions.py
@@ -419,7 +419,8 @@ class Definitions:
                 "old_database",
                 "create_dashboard",
                 "dashboard_folder_path",
-                "loadedSystem"
+                "loadedSystem",
+                "processStats"
             ],
             retention_policy=cls._RP_DAYS_14(),
             continuous_queries=[
@@ -970,18 +971,18 @@ class Definitions:
             fields={
                 '%CPU':                     Datatype.FLOAT,
                 '%MEM':                     Datatype.FLOAT,
-                'RES':                      Datatype.INT,
-                'SHR':                      Datatype.INT,
+                'RES':                      Datatype.INT, #TODO DELETE
+                'SHR':                      Datatype.INT, #TODO DELETE
                 'TIME+':                    Datatype.INT,
                 'VIRT':                     Datatype.INT,
                 'MEM_ABS':                  Datatype.INT
             },
             tags=[
                 'COMMAND',
-                'NI',
+                'NI',  #TODO DELETE
                 'PID',
-                'PR',
-                'S',
+                'PR',  #TODO DELETE
+                'S',  #TODO DELETE
                 'USER',
                 'hostName',
                 'ssh_type'

--- a/python/sppConnection/ssh_client.py
+++ b/python/sppConnection/ssh_client.py
@@ -52,7 +52,7 @@ class SshCommand:
         return self.__cmd
 
     @property
-    def table_name(self) -> str:
+    def table_name(self) -> Optional[str]:
         """name of table the result should be saved in"""
         return self.__table_name
 
@@ -75,7 +75,7 @@ class SshCommand:
         self.__result: Optional[str] = result
         self.__host_name: Optional[str] = host_name
 
-    def parse_result(self, ssh_type: SshTypes) -> Tuple[str, List[Dict[str, Any]]]:
+    def parse_result(self, ssh_type: SshTypes) -> Optional[Tuple[str, List[Dict[str, Any]]]]:
         """Use the function saved within this query to parse the result once existent.
 
         Arguments:
@@ -84,7 +84,10 @@ class SshCommand:
         Returns:
             Tuple[str, List[Dict[Any, Any]]] -- [description]
         """
-        return self.__parse_function(self, ssh_type)
+        if(self.__parse_function):
+            return self.__parse_function(self, ssh_type)
+        else:
+            return None
 
     def save_result(self, result: Optional[str], host_name: str) -> SshCommand:
         """Creates a new SshCommand with optional hostname and result saved.

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -41,6 +41,7 @@ Author:
  08/25/2020 version 0.10.1 Fixes to Transfer Data, Parse Unit and Top-SSH-Command parsing
  09/01/2020 version 0.10.2 Parse_Unit fixes (JobLogs) and adjustments on timeout
  11/10/2020 version 0.10.3 Introduced --loadedSystem argument and moved --minimumLogs to depricated
+ 12/29/2020 version 0.10.4 Replaced ssh 'top' command by 'ps' command to bugfix truncating data
 
 """
 from __future__ import annotations
@@ -70,7 +71,7 @@ from utils.methods_utils import MethodUtils
 from utils.spp_utils import SppUtils
 
 # Version:
-VERSION = "0.10.3  (2020/11/10)"
+VERSION = "0.10.4  (2020/12/29)"
 
 # ----------------------------------------------------------------------------
 # command line parameter parsing

--- a/python/sppmonMethods/ssh.py
+++ b/python/sppmonMethods/ssh.py
@@ -116,7 +116,7 @@ class SshMethods:
         for grep_name in top_grep_list:
             self.__client_commands[SshTypes.SERVER].append(
                 SshCommand(
-                    command=f"top -b -n1 -p $(pgrep -d',' -f {grep_name})",
+                    command=f"top -bs -w 512 -n1 -p $(pgrep -d',' -f {grep_name})",
                     parse_function=SshMethods._parse_top_cmd,
                     table_name="processStats"
                 )
@@ -195,6 +195,8 @@ class SshMethods:
             raise ValueError("no command given or empty result")
         if(not ssh_type):
             raise ValueError("no sshtype given")
+        if(not ssh_command.table_name):
+            raise ValueError("need table name to insert parsed value")
 
         result_lines = ssh_command.result.splitlines()
 
@@ -259,6 +261,8 @@ class SshMethods:
             raise ValueError("no command given or empty result")
         if(not ssh_type):
             raise ValueError("no sshtype given")
+        if(not ssh_command.table_name):
+            raise ValueError("need table name to insert parsed value")
 
         pool_result_list: List[Dict[str, Any]] = []
 
@@ -341,6 +345,8 @@ class SshMethods:
             raise ValueError("no command given or empty result")
         if(not ssh_type):
             raise ValueError("no sshtype given")
+        if(not ssh_command.table_name):
+            raise ValueError("need table name to insert parsed value")
 
         try:
             insert_dict: Dict[str, Any] = json.loads(ssh_command.result)
@@ -377,6 +383,8 @@ class SshMethods:
             raise ValueError("no command given or empty result")
         if(not ssh_type):
             raise ValueError("no sshtype given")
+        if(not ssh_command.table_name):
+            raise ValueError("need table name to insert parsed value")
 
         result_lines = ssh_command.result.splitlines()
         header = result_lines[0].split()
@@ -419,6 +427,8 @@ class SshMethods:
             raise ValueError("no command given or empty result")
         if(not ssh_type):
             raise ValueError("no sshtype given")
+        if(not ssh_command.table_name):
+            raise ValueError("need table name to insert parsed value")
 
         pattern = re.compile(r"(.*)\s+\((.*)\)\s+(\d{2}\/\d{2}\/\d{4})\s+(\S*)\s+\((\d+)\sCPU\)")
 
@@ -477,6 +487,8 @@ class SshMethods:
             raise ValueError("no command given or empty result")
         if(not ssh_type):
             raise ValueError("no sshtype given")
+        if(not ssh_command.table_name):
+            raise ValueError("need table name to insert parsed value")
 
         result_lines = ssh_command.result.splitlines()
         header = result_lines[0].split()

--- a/python/sppmonMethods/ssh.py
+++ b/python/sppmonMethods/ssh.py
@@ -110,14 +110,13 @@ class SshMethods:
         # ################ MULTI COMMAND ADD ##########################
 
         # SERVER
-
         # add server later due multiple processes
-        top_grep_list = ["mongod", "beam.smp", "java"] # be aware this is double declared below
-        for grep_name in top_grep_list:
+        self.__ps_grep_list = ["mongod", "beam.smp", "java"] # be aware this is double declared below
+        for grep_name in self.__ps_grep_list:
             self.__client_commands[SshTypes.SERVER].append(
                 SshCommand(
-                    command=f"top -bs -w 512 -n1 -p $(pgrep -d',' -f {grep_name})",
-                    parse_function=SshMethods._parse_top_cmd,
+                    command=f"ps -o \"%cpu,%mem,comm,rss,vsz,user,pid,etimes\" -p $(pgrep -d',' -f {grep_name}) S -ww",
+                    parse_function=self._parse_ps_cmd,
                     table_name="processStats"
                 )
             )
@@ -176,9 +175,8 @@ class SshMethods:
                 ExceptionUtils.exception_info(
                     error=error, extra_message=f"Top-level-error when excecuting {ssh_type.value} ssh commands, skipping them all")
 
-    @staticmethod
-    def _parse_top_cmd(ssh_command: SshCommand, ssh_type: SshTypes) -> Tuple[str, List[Dict[str, Any]]]:
-        """Parses the result of the `top` command, splitting it into its parts.
+    def _parse_ps_cmd(self, ssh_command: SshCommand, ssh_type: SshTypes) -> Tuple[str, List[Dict[str, Any]]]:
+        """Parses the result of the `df` command, splitting it into its parts.
 
         Arguments:
             ssh_command {SshCommand} -- command with saved result
@@ -197,23 +195,13 @@ class SshMethods:
             raise ValueError("no sshtype given")
         if(not ssh_command.table_name):
             raise ValueError("need table name to insert parsed value")
-
         result_lines = ssh_command.result.splitlines()
-
-        header = result_lines[6].split()
+        header = result_lines[0].split()
         values: List[Dict[str, Any]] = list(
-            map(lambda row: dict(zip(header, row.split())), result_lines[7:])) # type: ignore
-
-        ram_line = result_lines[3].split()
-        total_mem = SppUtils.parse_unit(
-            data=ram_line[3],
-            given_unit="KiB"
-        )
-
-        time_pattern = re.compile(r"(\d+):(\d{2})(?:\.(\d{2}))?")
+            map(lambda row: dict(zip(header, row.split())), result_lines[1:])) # type: ignore
 
         # remove top statistic itself to avoid spam with useless information
-        values = list(filter(lambda row: row["COMMAND"] in ["mongod", "beam.smp", "java"], values))
+        values = list(filter(lambda row: row["COMMAND"] in self.__ps_grep_list, values))
 
         for row in values:
             # set default needed fields
@@ -222,23 +210,10 @@ class SshMethods:
             (time_key, time_value) = SppUtils.get_capture_timestamp_sec()
             row[time_key] = time_value
 
-            # split time into seconds
-            match = re.match(time_pattern, row['TIME+'])
-            if(match):
-                time_list = match.groups()
-                (hours, minutes, seconds) = time_list
-                if(seconds is None):
-                    seconds = 0
-                time = int(hours)*pow(60, 2) + int(minutes)*pow(60, 1) + int(seconds)*pow(60, 0)
-            else:
-                time = None
-            row['TIME+'] = time
+            row['TIME+'] = row.pop('ELAPSED')
 
-            row['MEM_ABS'] = int((float(row['%MEM']) * total_mem) / 100 )
-
-            row['SHR'] = SppUtils.parse_unit(row['SHR'])
-            row['RES'] = SppUtils.parse_unit(row['RES'])
-            row['VIRT'] = SppUtils.parse_unit(row['VIRT'])
+            row['MEM_ABS'] = SppUtils.parse_unit(row.pop("RSS"),"kib")
+            row['VIRT'] = SppUtils.parse_unit(row.pop('VSZ'), "kib")
 
         return (ssh_command.table_name, values)
 

--- a/python/utils/methods_utils.py
+++ b/python/utils/methods_utils.py
@@ -59,7 +59,7 @@ class MethodUtils:
             return []
 
         ssh_cmd_response_list = []
-        result_list = []
+        result_list: List[Tuple[str, List[Dict[str, Any]]]] = []
         for client in client_list:
 
             if(cls.verbose):
@@ -88,7 +88,8 @@ class MethodUtils:
 
                 try:
                     table_result_tuple = ssh_command.parse_result(ssh_type=ssh_type)
-                    result_list.append(table_result_tuple)
+                    if(table_result_tuple):
+                        result_list.append(table_result_tuple)
                 except ValueError as error:
                     ExceptionUtils.exception_info(error=error, extra_message="Error when parsing result, skipping parsing of this result")
 


### PR DESCRIPTION
Due a issue with truncating data (see #14 & Slack issues) it is required to change the unit within the TOP-command. 
This is possible by programm arguments but require a certain version. Since it is not practicable to force all SPPMon users to upgrade their VM's, I've decided it's better to replace it by the `ps` command.
- The `ps` command is made for static request like we do, while top is made rather for a interative mode
- By using `ps` we can define more careful which information we like to request and which format they should have.

Therefore I've removed some unneccessary and unused information while defining our requested information more carefully, preventing bugs due new `ps` versions.

Changelog:

- Ssh_Commands now allow `None` as parse_function and table_name, allowing commands with no return value. 
- Removed some unused and redundant tags and fields from the processStats-table
- replaced the top command by the ps command (fixes Issue #14 )
