### PR TITLE
Copy_database

### DIFF
--- a/python/influx/database_tables.py
+++ b/python/influx/database_tables.py
@@ -188,6 +188,8 @@ class Table:
         fields - dict of field name with datatype
         tags - tags as list of str
         time_key - key name of the timestamp field
+        retention_policy - retention policy associated with this table
+        database - table is declared within this database
 
     Methods
         split_by_table_def - Split the given dict into a pre-defined set of tags, fields and a timestamp.

--- a/python/influx/definitions.py
+++ b/python/influx/definitions.py
@@ -456,7 +456,8 @@ class Definitions:
                 "create_dashboard",
                 "dashboard_folder_path",
                 "loadedSystem",
-                "processStats"
+                "processStats",
+                "copy_database"
             ],
             retention_policy=cls._RP_DAYS_14(),
             continuous_queries=[

--- a/python/influx/influx_client.py
+++ b/python/influx/influx_client.py
@@ -251,7 +251,7 @@ class InfluxClient:
         if(not new_database_name):
             raise ValueError("copy_database requires a new database name to copy to.")
         LOGGER.info(f"transfering the data from database {self.database.name} into {new_database_name}.")
-        LOGGER.info("This also includes all data from `autogen` retention policy, sorted into new retention policies.")
+        LOGGER.info("This also includes all data from `autogen` retention policy, sorted into the correct retention policies.")
         LOGGER.info("Computing queries to be send to the server.")
 
         queries: List[str] = []
@@ -319,7 +319,6 @@ class InfluxClient:
         send_time_collection: float = 0
         # line count since last print
         line_collection: int = 0
-        LOGGER.info("starting transfer of data")
 
         # disable timeout
         old_timeout = self.__client._timeout
@@ -334,7 +333,8 @@ class InfluxClient:
         )
         # ping to make sure connection works
         version: str = self.__client.ping()
-        LOGGER.info(f"Connected again to influxdb with new timeout of {self.__client._timeout}, version: {version}")
+        LOGGER.info(f"Connected to influxdb with new timeout of {self.__client._timeout}, version: {version}")
+        LOGGER.info("starting transfer of data")
         i = 0
 
         for query in queries:
@@ -387,7 +387,7 @@ class InfluxClient:
         )
         # ping to make sure connection works
         version: str = self.__client.ping()
-        LOGGER.info(f"Connected again to influxdb with old timeout of {self.__client._timeout}, version: {version}")
+        LOGGER.info(f"Changed timeout of influxDB to old timeout of {self.__client._timeout}, version: {version}")
 
         LOGGER.info(f"Total transfered {line_count} lines of results.")
         if(dropped_count):

--- a/python/influx/influx_queries.py
+++ b/python/influx/influx_queries.py
@@ -356,13 +356,14 @@ class SelectionQuery:
 class ContinuousQuery:
     """Structure for a Continuous Query with a SELECT-INTO-Query inside.
 
-    Use `to_query` to format data into a string. Do not create a instance outside of module definitons.py
+    Use `to_query` to format data into a string. Do not create a instance outside of module `definitons.py`
     __eq__ and __hash__ implemented for SET-use.
 
     Attributes:
         name - name of the CQ
         database - database affected by CQ
         select - SELECT-Query as str to be send to influxdb
+        select_query - SelectionQuery used to generate CQ if not done by string.
         resample_opts - RESAMPLE-Clause as str to be send to influxdb
 
     Methods:
@@ -385,11 +386,11 @@ class ContinuousQuery:
         """SELECT-Query as str to be send to influxdb"""
         if(self.select_query):
             return self.select_query.to_query()
-        return self.__select_str # this is clearyl not None, execption catch in __init__
+        return self.__select_str
 
     @property
     def select_query(self) -> Optional[SelectionQuery]:
-        """SelectionQuery if used to create, be aware its optional."""
+        """SelectionQuery used to create query, None if query is given as str."""
         return self.__select_query
 
     @property

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -123,7 +123,7 @@ parser.add_option("--minimumLogs", dest="minimumLogs", action="store_true",
 parser.add_option("--copy_database", dest="copy_database",
                   help="Copy all data from .cfg database into a new database, specified by `copy_database=newName`. Delete old database with caution.")
 parser.add_option("--create_dashboard", dest="create_dashboard", action="store_true",
-                  help="Create a server unique dashboard with alerts. Option `--cfg` required.")
+                  help="Create a server unique dashboard with alerts. Option `--cfg` and `--dashboard_folder_path` required.")
 parser.add_option("--dashboard_folder_path", dest="dashboard_folder_path",
                   help="Used only with`--create_dashboard` option. Specifies changed folder-path of the template \"SPPMON for IBM Spectrum Protect Plus\" dashboard.")
 
@@ -839,13 +839,17 @@ class SppMon:
 
         if(OPTIONS.create_dashboard):
             try:
-                OtherMethods.create_dashboard(
-                    dashboard_folder_path=OPTIONS.dashboard_folder_path,
-                    database_name=self.influx_client.database.name)
+                if(not OPTIONS.dashboard_folder_path):
+                    ExceptionUtils.error_message(
+                        "Only use --create_dashboard in combination with --dashboard_folder_path=\"PATH/TO/GRAFANA/FOLDER/\"")
+                else:
+                    OtherMethods.create_dashboard(
+                        dashboard_folder_path=OPTIONS.dashboard_folder_path,
+                        database_name=self.influx_client.database.name)
             except ValueError as error:
                 ExceptionUtils.exception_info(
                     error=error,
-                    extra_message="Top-level-error when creating dashboards")
+                    extra_message="Top-level-error when creating dashboard")
 
         if(OPTIONS.copy_database):
             try:

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -115,17 +115,16 @@ parser.add_option("--cpu", dest="cpu", action="store_true", help="capture SPP se
 parser.add_option("--sppcatalog", dest="sppcatalog", action="store_true", help="capture Spp-Catalog Storage usage")
 
 ##########################
-#TODO Remove minimum Logs on next version.
+#TODO Minimum Logs is depricated, to be removed in Version 1.1.
 parser.add_option("--minimumLogs", dest="minimumLogs", action="store_true",
-                  help="DEPRICATED, use '--loadedSystem' instead")
-parser.add_option("--transfer_data", dest="transfer_data", action="store_true",
-                  help="TEMPORARY FEATURE:transfer data into retention policies, BACKUP before doing so")
-parser.add_option("--old_database", dest="old_database",
-                  help="TEMPORARY FEATURE:transfer data of this db into the cfg-database")
+                  help="DEPRICATED, use '--loadedSystem' instead. To be removed in v1.1")
+
+parser.add_option("--rename_database", dest="rename_database",
+                  help="Copy all data from .cfg database into a new database, specified by `rename_database=newName`. Delete old database with caution.")
 parser.add_option("--create_dashboard", dest="create_dashboard", action="store_true",
-                  help="Create a 14-day dashboard with alerts for the given spp-server. CFG and dashboard path required")
+                  help="Create a server unique dashboard with alerts. Option `--cfg` required.")
 parser.add_option("--dashboard_folder_path", dest="dashboard_folder_path",
-                  help="Only in use with create_dashboard. Path to the folder of the \"SPPMON for IBM Spectrum Protect Plus\" dashboard")
+                  help="Used only with`--create_dashboard` option. Specifies changed folder-path of the template \"SPPMON for IBM Spectrum Protect Plus\" dashboard.")
 
 
 (OPTIONS, ARGS) = parser.parse_args()
@@ -847,14 +846,9 @@ class SppMon:
                     error=error,
                     extra_message="Top-level-error when creating dashboards")
 
-        # ######################   DISCLAMER   #######################
-        # ###################  TEMPORARY FEATURE  ####################
-        # this part is deleted once all old versions of SPPMon have been migrated
-        # use at own caution
-        # ############################################################
-        if(OPTIONS.transfer_data):
+        if(OPTIONS.rename_database):
             try:
-                self.influx_client.transfer_data(OPTIONS.old_database)
+                self.influx_client.copy_database(OPTIONS.rename_database)
             except ValueError as error:
                 ExceptionUtils.exception_info(
                     error=error,

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -43,6 +43,7 @@ Author:
  11/10/2020 version 0.10.3 Introduced --loadedSystem argument and moved --minimumLogs to depricated
  12/07/2020 version 0.10.4 Included SPP 10.1.6 addtional job information features and some bugfixes
  12/29/2020 version 0.10.5 Replaced ssh 'top' command by 'ps' command to bugfix truncating data
+ 01/22/2021 version 0.10.6 Replaced `transfer_data` by `copy_database` with improvements
 """
 from __future__ import annotations
 import functools
@@ -71,7 +72,7 @@ from utils.methods_utils import MethodUtils
 from utils.spp_utils import SppUtils
 
 # Version:
-VERSION = "0.10.5  (2020/12/29)"
+VERSION = "0.10.6  (2021/01/22)"
 
 # ----------------------------------------------------------------------------
 # command line parameter parsing
@@ -119,8 +120,8 @@ parser.add_option("--sppcatalog", dest="sppcatalog", action="store_true", help="
 parser.add_option("--minimumLogs", dest="minimumLogs", action="store_true",
                   help="DEPRICATED, use '--loadedSystem' instead. To be removed in v1.1")
 
-parser.add_option("--rename_database", dest="rename_database",
-                  help="Copy all data from .cfg database into a new database, specified by `rename_database=newName`. Delete old database with caution.")
+parser.add_option("--copy_database", dest="copy_database",
+                  help="Copy all data from .cfg database into a new database, specified by `copy_database=newName`. Delete old database with caution.")
 parser.add_option("--create_dashboard", dest="create_dashboard", action="store_true",
                   help="Create a server unique dashboard with alerts. Option `--cfg` required.")
 parser.add_option("--dashboard_folder_path", dest="dashboard_folder_path",
@@ -846,13 +847,13 @@ class SppMon:
                     error=error,
                     extra_message="Top-level-error when creating dashboards")
 
-        if(OPTIONS.rename_database):
+        if(OPTIONS.copy_database):
             try:
-                self.influx_client.copy_database(OPTIONS.rename_database)
+                self.influx_client.copy_database(OPTIONS.copy_database)
             except ValueError as error:
                 ExceptionUtils.exception_info(
                     error=error,
-                    extra_message="Top-level-error when transfering data storages.")
+                    extra_message="Top-level-error when coping database.")
 
         self.exit()
 

--- a/python/sppmonMethods/other.py
+++ b/python/sppmonMethods/other.py
@@ -5,6 +5,7 @@ Classes:
     OtherMethods
 """
 import logging
+import os
 import re
 
 from utils.execption_utils import ExceptionUtils
@@ -29,20 +30,23 @@ class OtherMethods:
             ValueError: error when reading or writing files
         """
         if(not dashboard_folder_path):
-            raise ValueError("need a path to the dashboard template to create a new dashboard")
+            raise ValueError("a path to the dashboard template is required to create a new dashboard")
         if(not database_name):
             raise ValueError("need the name of the database to create the new dashboard")
 
-        tmpl_path = dashboard_folder_path + "SPPMON for IBM Spectrum Protect Plus.json"
-        LOGGER.info(f"trying to open template dashboard on path {tmpl_path}")
+        real_path = os.path.realpath(dashboard_folder_path)
+        tmpl_path = os.path.join(real_path, "SPPMON for IBM Spectrum Protect Plus.json")
+
+        LOGGER.info(f"> trying to open template dashboard on path {tmpl_path}")
+
         try:
             tmpl_file = open(tmpl_path, "rt")
             file_str = tmpl_file.read()
             tmpl_file.close()
         except Exception as error:
             ExceptionUtils.exception_info(error)
-            raise ValueError("Error opening template dashboard. Make sure you've entered only the path to the folder.")
-        LOGGER.info("Sucessfully opened. Starting replacing")
+            raise ValueError("Error opening dashboard template. Make sure you've the path to the correct folder (Grafana).")
+        LOGGER.info("> Sucessfully opened. Creating new Dashboard")
         # replace name by new one
         name_str = file_str.replace(
             "\"title\": \"SPPMON for IBM Spectrum Protect Plus\"",
@@ -60,13 +64,14 @@ class OtherMethods:
             f"\"datasource\": \"{database_name}\"",
         )
 
-        dashboard_path = dashboard_folder_path + f"SPPMON for IBM Spectrum Protect Plus {database_name}.json"
-        LOGGER.info(f"trying to create new dashboard on path {dashboard_path}")
+        LOGGER.info("> finished creating content of dashboard")
+        write_path = os.path.join(real_path, f"SPPMON for IBM Spectrum Protect Plus {database_name}.json")
+        LOGGER.info(f"> trying to create dashboard file on path {write_path}")
         try:
-            dashboard_file = open(dashboard_path, "wt")
+            dashboard_file = open(write_path, "wt")
             dashboard_file.write(datasource_str)
             dashboard_file.close()
         except Exception as error:
             ExceptionUtils.exception_info(error)
             raise ValueError("Error creating new dashboard file.")
-        LOGGER.info("Sucessfully created.")
+        LOGGER.info("> Sucessfully created new dashboard file.")

--- a/python/utils/spp_utils.py
+++ b/python/utils/spp_utils.py
@@ -45,8 +45,8 @@ class SppUtils:
     """name of the single timestamp capture to allow same naming within the db"""
 
     @staticmethod
-    def filename_of_config(conf_file: str, fileending: str) -> str:
-        """returns a filepath to the logdir out of the config file + a new fileending
+    def filename_of_config(conf_file_path: str, fileending: str) -> str:
+        """returns a filepath to the home / sppmonLogs out of the config file + a new fileending
 
         Args:
             conf_file (str): name of the configfile incl. path
@@ -55,11 +55,10 @@ class SppUtils:
         Returns:
             str: full path to the file
         """
-        if(conf_file):
-            cfg_file = conf_file
-
+        if(conf_file_path):
+            real_path = os.path.realpath(conf_file_path)
             # get everything behind the last slash
-            config_name = os.path.basename(cfg_file)
+            config_name = os.path.basename(real_path)
             # get name without fileending
             config_name = config_name.split('.')[-2]
 


### PR DESCRIPTION
- Addtion to commit (68910591e5330ab3e60dd4c546edd0eca72b035b)
- Removes `transfer_data` and transforms it into `copy_database`
- Allows a rename of a database while maintaining the functionality of `transfer_data`
- Now takes the old db in the .cfg file, new database specified by `--copy_database=NewName`
- Preparation for #28 and the improvement of the wiki / some users may need to rename their database