### PR TITLE
Shh df extension

### DIFF
--- a/Grafana/Multiple Server Overview.json
+++ b/Grafana/Multiple Server Overview.json
@@ -17,8 +17,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 27,
-  "iteration": 1601761461271,
+  "id": 28,
+  "iteration": 1611415376873,
   "links": [],
   "panels": [
     {
@@ -36,8 +36,8 @@
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "title": "$SPP_Server Overview",
@@ -95,12 +95,12 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -195,12 +195,12 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -246,7 +246,7 @@
     {
       "cacheTimeout": null,
       "datasource": null,
-      "description": "95% Percentille / last 24h of each component memory usage",
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -277,7 +277,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 4,
+        "w": 5,
         "x": 10,
         "y": 1
       },
@@ -295,12 +295,12 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -342,6 +342,61 @@
             ]
           ],
           "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
         }
       ],
       "timeFrom": null,
@@ -392,8 +447,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 10,
-        "x": 14,
+        "w": 9,
+        "x": 15,
         "y": 1
       },
       "id": 136,
@@ -412,12 +467,12 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -490,7 +545,7 @@
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
         "x": 0,
         "y": 8
@@ -513,16 +568,19 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "seriesOverrides": [],
@@ -675,7 +733,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 8,
         "y": 8
@@ -695,12 +753,12 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -762,7 +820,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 12,
         "y": 8
@@ -782,12 +840,12 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -849,7 +907,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 16,
         "y": 8
@@ -869,12 +927,12 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -948,7 +1006,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 20,
         "y": 8
@@ -968,12 +1026,12 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -1016,6 +1074,281 @@
     },
     {
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 11
+      },
+      "id": 98,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb11_new",
+          "value": "cb11_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 11
+      },
+      "hiddenSeries": false,
+      "id": 93,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb11_new",
+          "value": "cb11_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
       "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
       "fieldConfig": {
         "defaults": {
@@ -1041,10 +1374,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 7,
         "w": 4,
-        "x": 8,
-        "y": 12
+        "x": 16,
+        "y": 11
       },
       "id": 142,
       "interval": "24h",
@@ -1060,12 +1393,12 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -1252,160 +1585,6 @@
       "type": "gauge"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 12,
-        "y": 12
-      },
-      "hiddenSeries": false,
-      "id": 93,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "repeatDirection": "h",
-      "scopedVars": {
-        "SPP_Server": {
-          "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "Total",
-          "groupBy": [],
-          "measurement": "vmStats",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_90",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "vmCount"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Protected",
-          "groupBy": [],
-          "measurement": "vmStats",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_90",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "vmCountProtected"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Unprotected",
-          "groupBy": [],
-          "measurement": "vmStats",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_90",
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "vmCountUnprotected"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "VM Statistics",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
       "cacheTimeout": null,
       "datasource": null,
       "description": "",
@@ -1440,8 +1619,8 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 16,
-        "y": 12
+        "x": 20,
+        "y": 11
       },
       "id": 128,
       "interval": null,
@@ -1461,12 +1640,12 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -1500,100 +1679,6 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Catalog Backup Duration",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "noValue": "N/A",
-          "nullValueMode": "connected",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 12
-      },
-      "id": 143,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.3",
-      "scopedVars": {
-        "SPP_Server": {
-          "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Catalog Backup",
-          "groupBy": [
-            {
-              "params": [
-                "24h"
-              ],
-              "type": "time"
-            }
-          ],
-          "measurement": "jobs",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_90",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "jobLogsCount"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Job Logs Stored 24h",
       "type": "stat"
     },
     {
@@ -1632,7 +1717,7 @@
         "h": 6,
         "w": 4,
         "x": 0,
-        "y": 16
+        "y": 15
       },
       "id": 97,
       "interval": "",
@@ -1648,12 +1733,12 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -1747,7 +1832,7 @@
         "h": 6,
         "w": 4,
         "x": 4,
-        "y": 16
+        "y": 15
       },
       "id": 99,
       "interval": "1h",
@@ -1763,12 +1848,12 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -1827,124 +1912,6 @@
       "type": "bargauge"
     },
     {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "noValue": "N/A",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 65
-              },
-              {
-                "color": "red",
-                "value": 85
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 16,
-        "y": 16
-      },
-      "id": 98,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.3",
-      "scopedVars": {
-        "SPP_Server": {
-          "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
-        }
-      },
-      "targets": [
-        {
-          "alias": "$tag_ssh_type",
-          "groupBy": [
-            {
-              "params": [
-                "24h"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "ssh_type"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "ssh_mpstat_cmd",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_14",
-          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "%idle"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "min"
-              },
-              {
-                "params": [
-                  "*-1 + 100"
-                ],
-                "type": "math"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Highest CPU load by Component",
-      "type": "stat"
-    },
-    {
       "cacheTimeout": null,
       "datasource": null,
       "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
@@ -1971,7 +1938,7 @@
         "h": 6,
         "w": 4,
         "x": 20,
-        "y": 16
+        "y": 15
       },
       "id": 125,
       "interval": null,
@@ -1991,12 +1958,12 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -2106,7 +2073,7 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 19
+        "y": 18
       },
       "id": 144,
       "options": {
@@ -2123,13 +2090,13 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "repeatDirection": "h",
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "cetSPP",
-          "value": "cetSPP"
+          "text": "cb11_new",
+          "value": "cb11_new"
         }
       },
       "targets": [
@@ -2172,24 +2139,117 @@
       "type": "stat"
     },
     {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 18
+      },
+      "id": 143,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb11_new",
+          "value": "cb11_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 21
       },
       "id": 145,
       "panels": [],
-      "repeat": null,
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 60,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "title": "$SPP_Server Overview",
@@ -2231,7 +2291,7 @@
         "h": 7,
         "w": 5,
         "x": 0,
-        "y": 23
+        "y": 22
       },
       "id": 146,
       "interval": "",
@@ -2247,15 +2307,15 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 95,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -2335,7 +2395,7 @@
         "h": 7,
         "w": 5,
         "x": 5,
-        "y": 23
+        "y": 22
       },
       "id": 147,
       "options": {
@@ -2350,15 +2410,15 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 96,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -2404,7 +2464,7 @@
     {
       "cacheTimeout": null,
       "datasource": null,
-      "description": "95% Percentille / last 24h of each component memory usage",
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -2435,9 +2495,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 4,
+        "w": 5,
         "x": 10,
-        "y": 23
+        "y": 22
       },
       "id": 148,
       "links": [],
@@ -2453,15 +2513,15 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 45,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -2503,6 +2563,61 @@
             ]
           ],
           "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
         }
       ],
       "timeFrom": null,
@@ -2553,9 +2668,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 10,
-        "x": 14,
-        "y": 23
+        "w": 9,
+        "x": 15,
+        "y": 22
       },
       "id": 149,
       "links": [],
@@ -2573,15 +2688,15 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 136,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -2654,10 +2769,10 @@
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
         "x": 0,
-        "y": 30
+        "y": 29
       },
       "hiddenSeries": false,
       "id": 150,
@@ -2677,19 +2792,22 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "seriesOverrides": [],
@@ -2842,10 +2960,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 8,
-        "y": 30
+        "y": 29
       },
       "id": 151,
       "options": {
@@ -2862,15 +2980,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 139,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -2932,10 +3050,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 12,
-        "y": 30
+        "y": 29
       },
       "id": 152,
       "options": {
@@ -2952,15 +3070,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 140,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -3022,10 +3140,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 16,
-        "y": 30
+        "y": 29
       },
       "id": 153,
       "options": {
@@ -3042,15 +3160,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 138,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -3124,10 +3242,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 20,
-        "y": 30
+        "y": 29
       },
       "id": 154,
       "options": {
@@ -3144,15 +3262,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 141,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -3195,6 +3313,287 @@
     },
     {
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 32
+      },
+      "id": 155,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 98,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb4_new",
+          "value": "cb4_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 32
+      },
+      "hiddenSeries": false,
+      "id": 156,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 93,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb4_new",
+          "value": "cb4_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
       "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
       "fieldConfig": {
         "defaults": {
@@ -3220,12 +3619,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 7,
         "w": 4,
-        "x": 8,
-        "y": 34
+        "x": 16,
+        "y": 32
       },
-      "id": 155,
+      "id": 157,
       "interval": "24h",
       "options": {
         "orientation": "auto",
@@ -3239,15 +3638,15 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 142,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -3434,163 +3833,6 @@
       "type": "gauge"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 12,
-        "y": 34
-      },
-      "hiddenSeries": false,
-      "id": 156,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "repeatDirection": "h",
-      "repeatIteration": 1601761461271,
-      "repeatPanelId": 93,
-      "repeatedByRow": true,
-      "scopedVars": {
-        "SPP_Server": {
-          "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "Total",
-          "groupBy": [],
-          "measurement": "vmStats",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_90",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "vmCount"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Protected",
-          "groupBy": [],
-          "measurement": "vmStats",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_90",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "vmCountProtected"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Unprotected",
-          "groupBy": [],
-          "measurement": "vmStats",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_90",
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "vmCountUnprotected"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "VM Statistics",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
       "cacheTimeout": null,
       "datasource": null,
       "description": "",
@@ -3625,100 +3867,8 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 16,
-        "y": 34
-      },
-      "id": 157,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
-      "repeatPanelId": 128,
-      "repeatedByRow": true,
-      "scopedVars": {
-        "SPP_Server": {
-          "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Catalog Backup",
-          "groupBy": [],
-          "measurement": "jobs",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_90",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "duration"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "jobName",
-              "operator": "=~",
-              "value": "/.*catalog.*/"
-            }
-          ]
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Catalog Backup Duration",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "noValue": "N/A",
-          "nullValueMode": "connected",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
         "x": 20,
-        "y": 34
+        "y": 32
       },
       "id": 158,
       "interval": null,
@@ -3738,28 +3888,21 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
-      "repeatPanelId": 143,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 128,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
         {
           "alias": "Catalog Backup",
-          "groupBy": [
-            {
-              "params": [
-                "24h"
-              ],
-              "type": "time"
-            }
-          ],
+          "groupBy": [],
           "measurement": "jobs",
           "orderByTime": "ASC",
           "policy": "$SPP_Server\".\"rp_days_90",
@@ -3769,22 +3912,24 @@
             [
               {
                 "params": [
-                  "jobLogsCount"
+                  "duration"
                 ],
                 "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            }
+          ]
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Job Logs Stored 24h",
+      "title": "Catalog Backup Duration",
       "type": "stat"
     },
     {
@@ -3823,7 +3968,7 @@
         "h": 6,
         "w": 4,
         "x": 0,
-        "y": 38
+        "y": 36
       },
       "id": 159,
       "interval": "",
@@ -3839,15 +3984,15 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -3941,7 +4086,7 @@
         "h": 6,
         "w": 4,
         "x": 4,
-        "y": 38
+        "y": 36
       },
       "id": 160,
       "interval": "1h",
@@ -3957,15 +4102,15 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 99,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -4024,127 +4169,6 @@
       "type": "bargauge"
     },
     {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "noValue": "N/A",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 65
-              },
-              {
-                "color": "red",
-                "value": 85
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 16,
-        "y": 38
-      },
-      "id": 161,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
-      "repeatPanelId": 98,
-      "repeatedByRow": true,
-      "scopedVars": {
-        "SPP_Server": {
-          "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
-        }
-      },
-      "targets": [
-        {
-          "alias": "$tag_ssh_type",
-          "groupBy": [
-            {
-              "params": [
-                "24h"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "ssh_type"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "ssh_mpstat_cmd",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_14",
-          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "%idle"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "min"
-              },
-              {
-                "params": [
-                  "*-1 + 100"
-                ],
-                "type": "math"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Highest CPU load by Component",
-      "type": "stat"
-    },
-    {
       "cacheTimeout": null,
       "datasource": null,
       "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
@@ -4171,9 +4195,9 @@
         "h": 6,
         "w": 4,
         "x": 20,
-        "y": 38
+        "y": 36
       },
-      "id": 162,
+      "id": 161,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -4191,15 +4215,15 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 125,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -4232,7 +4256,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
         },
         {
           "alias": "Backuped Bytes",
@@ -4263,7 +4293,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
         }
       ],
       "timeFrom": null,
@@ -4297,9 +4333,9 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 41
+        "y": 39
       },
-      "id": 163,
+      "id": 162,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -4314,16 +4350,16 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "repeatDirection": "h",
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 144,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "devSPPv2",
-          "value": "devSPPv2"
+          "text": "cb4_new",
+          "value": "cb4_new"
         }
       },
       "targets": [
@@ -4366,24 +4402,120 @@
       "type": "stat"
     },
     {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 39
+      },
+      "id": 163,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb4_new",
+          "value": "cb4_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 42
       },
       "id": 164,
       "panels": [],
-      "repeat": null,
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 60,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "title": "$SPP_Server Overview",
@@ -4425,7 +4557,7 @@
         "h": 7,
         "w": 5,
         "x": 0,
-        "y": 45
+        "y": 43
       },
       "id": 165,
       "interval": "",
@@ -4441,15 +4573,15 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 95,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "targets": [
@@ -4529,7 +4661,7 @@
         "h": 7,
         "w": 5,
         "x": 5,
-        "y": 45
+        "y": 43
       },
       "id": 166,
       "options": {
@@ -4544,15 +4676,15 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 96,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "targets": [
@@ -4598,7 +4730,7 @@
     {
       "cacheTimeout": null,
       "datasource": null,
-      "description": "95% Percentille / last 24h of each component memory usage",
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -4629,9 +4761,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 4,
+        "w": 5,
         "x": 10,
-        "y": 45
+        "y": 43
       },
       "id": 167,
       "links": [],
@@ -4647,15 +4779,15 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 45,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "targets": [
@@ -4697,6 +4829,61 @@
             ]
           ],
           "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
         }
       ],
       "timeFrom": null,
@@ -4747,9 +4934,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 10,
-        "x": 14,
-        "y": 45
+        "w": 9,
+        "x": 15,
+        "y": 43
       },
       "id": 168,
       "links": [],
@@ -4767,15 +4954,15 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 136,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "targets": [
@@ -4848,10 +5035,10 @@
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
         "x": 0,
-        "y": 52
+        "y": 50
       },
       "hiddenSeries": false,
       "id": 169,
@@ -4871,19 +5058,22 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "seriesOverrides": [],
@@ -5036,10 +5226,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 8,
-        "y": 52
+        "y": 50
       },
       "id": 170,
       "options": {
@@ -5056,15 +5246,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 139,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "targets": [
@@ -5126,10 +5316,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 12,
-        "y": 52
+        "y": 50
       },
       "id": 171,
       "options": {
@@ -5146,15 +5336,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 140,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "targets": [
@@ -5216,10 +5406,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 16,
-        "y": 52
+        "y": 50
       },
       "id": 172,
       "options": {
@@ -5236,15 +5426,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 138,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "targets": [
@@ -5318,10 +5508,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 20,
-        "y": 52
+        "y": 50
       },
       "id": 173,
       "options": {
@@ -5338,15 +5528,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 141,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "targets": [
@@ -5389,6 +5579,287 @@
     },
     {
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 53
+      },
+      "id": 174,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 98,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb5_new",
+          "value": "cb5_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 53
+      },
+      "hiddenSeries": false,
+      "id": 175,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 93,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb5_new",
+          "value": "cb5_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
       "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
       "fieldConfig": {
         "defaults": {
@@ -5414,12 +5885,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 7,
         "w": 4,
-        "x": 8,
-        "y": 56
+        "x": 16,
+        "y": 53
       },
-      "id": 174,
+      "id": 176,
       "interval": "24h",
       "options": {
         "orientation": "auto",
@@ -5433,15 +5904,15 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 142,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cb5_new",
+          "value": "cb5_new"
         }
       },
       "targets": [
@@ -5628,6 +6099,1872 @@
       "type": "gauge"
     },
     {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "light-orange",
+                "value": 36000000
+              },
+              {
+                "color": "#d44a3a",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 53
+      },
+      "id": 177,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 128,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb5_new",
+          "value": "cb5_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Catalog Backup Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h per Commandgroup",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 800,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 57
+      },
+      "id": 178,
+      "interval": "",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 97,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb5_new",
+          "value": "cb5_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%CPU\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER') GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%CPU"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP-Server Processes CPU Usage ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 57
+      },
+      "id": 179,
+      "interval": "1h",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 99,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb5_new",
+          "value": "cb5_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%MEM\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER')  GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%MEM"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Process RAM Usage",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 57
+      },
+      "id": 180,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 125,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb5_new",
+          "value": "cb5_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Replicated Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmReplicateStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "replicatedBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
+        },
+        {
+          "alias": "Backuped Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmBackupSummary",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "transferredBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VM Statistics (Total of last 24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 60
+      },
+      "id": 181,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^sppmon_metrics\\.spp_version$/",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 144,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb5_new",
+          "value": "cb5_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "spp_version"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Version",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 60
+      },
+      "id": 182,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cb5_new",
+          "value": "cb5_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 183,
+      "panels": [],
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 60,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "title": "$SPP_Server Overview",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 64
+      },
+      "id": 184,
+      "interval": "",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 95,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT percentile(\"cpuUtil\", 90) FROM \"rp_days_14\".\"cpuram\" WHERE $timeFilter GROUP BY time(24h)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server CPU Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 5,
+        "y": 64
+      },
+      "id": 185,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 96,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server RAM Usage",
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 10,
+        "y": 64
+      },
+      "id": 186,
+      "links": [],
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 45,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_name",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "sppcatalog",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "percentUsed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Catalog Space",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Duration of the last execution of selected jobs",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No Execution Recorded",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 36000000
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 64
+      },
+      "id": 187,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 136,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_jobName",
+          "groupBy": [
+            {
+              "params": [
+                "jobName"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Housekeeping-Job Durations",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 71
+      },
+      "hiddenSeries": false,
+      "id": 188,
+      "interval": "",
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 44,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "CPU-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "RAM-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "*100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU / RAM SPP-Server (REST)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:39939",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:39940",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": 10
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 71
+      },
+      "id": 189,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 139,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Maintenance",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 71
+      },
+      "id": 190,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 140,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Hypervisor Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 71
+      },
+      "id": 191,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 138,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "=",
+              "value": "COMPLETED"
+            },
+            {
+              "condition": "AND",
+              "key": "subPolicyType",
+              "operator": "=",
+              "value": "BACKUP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Catalog Backup",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 71
+      },
+      "id": 192,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 141,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Storage Server Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 74
+      },
+      "id": 193,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 98,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -5645,10 +7982,10 @@
         "h": 7,
         "w": 4,
         "x": 12,
-        "y": 56
+        "y": 74
       },
       "hiddenSeries": false,
-      "id": 175,
+      "id": 194,
       "legend": {
         "avg": false,
         "current": false,
@@ -5661,20 +7998,23 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 93,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
         }
       },
       "seriesOverrides": [],
@@ -5785,6 +8125,246 @@
       }
     },
     {
+      "datasource": null,
+      "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "max": 50,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 74
+      },
+      "id": 195,
+      "interval": "24h",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 142,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "--constant",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.\"rp_days_14\".\"sppmon_metrics\" WHERE $timeFilter AND (\"constant\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--hourly",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"hourly\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--daily",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"daily\" = 'True'))  GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--all",
+          "groupBy": [],
+          "limit": "",
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"all\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "all",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "others",
+          "groupBy": [],
+          "hide": true,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"daily\" != 'True' AND \"constant\" != 'True' AND \"all\" != 'True' AND \"hourly\" != 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "constant",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "all",
+              "operator": "!=",
+              "value": "True"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPPmon Collection Errors (24h)",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
       "cacheTimeout": null,
       "datasource": null,
       "description": "",
@@ -5819,10 +8399,10 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 16,
-        "y": 56
+        "x": 20,
+        "y": 74
       },
-      "id": 176,
+      "id": 196,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -5840,15 +8420,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 128,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
         }
       },
       "targets": [
@@ -5882,103 +8462,6 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Catalog Backup Duration",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "noValue": "N/A",
-          "nullValueMode": "connected",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 56
-      },
-      "id": 177,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
-      "repeatPanelId": 143,
-      "repeatedByRow": true,
-      "scopedVars": {
-        "SPP_Server": {
-          "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Catalog Backup",
-          "groupBy": [
-            {
-              "params": [
-                "24h"
-              ],
-              "type": "time"
-            }
-          ],
-          "measurement": "jobs",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_90",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "jobLogsCount"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Job Logs Stored 24h",
       "type": "stat"
     },
     {
@@ -6017,9 +8500,9 @@
         "h": 6,
         "w": 4,
         "x": 0,
-        "y": 60
+        "y": 78
       },
-      "id": 178,
+      "id": 197,
       "interval": "",
       "options": {
         "displayMode": "lcd",
@@ -6033,15 +8516,15 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
         }
       },
       "targets": [
@@ -6135,9 +8618,9 @@
         "h": 6,
         "w": 4,
         "x": 4,
-        "y": 60
+        "y": 78
       },
-      "id": 179,
+      "id": 198,
       "interval": "1h",
       "options": {
         "displayMode": "lcd",
@@ -6151,15 +8634,15 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 99,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
         }
       },
       "targets": [
@@ -6218,6 +8701,1415 @@
       "type": "bargauge"
     },
     {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 78
+      },
+      "id": 199,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 125,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Replicated Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmReplicateStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "replicatedBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
+        },
+        {
+          "alias": "Backuped Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmBackupSummary",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "transferredBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VM Statistics (Total of last 24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 81
+      },
+      "id": 200,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^sppmon_metrics\\.spp_version$/",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 144,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "spp_version"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Version",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 81
+      },
+      "id": 201,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "cetSPP EXTERNAL",
+          "value": "cetSPP EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 84
+      },
+      "id": 202,
+      "panels": [],
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 60,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "title": "$SPP_Server Overview",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 85
+      },
+      "id": 203,
+      "interval": "",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 95,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT percentile(\"cpuUtil\", 90) FROM \"rp_days_14\".\"cpuram\" WHERE $timeFilter GROUP BY time(24h)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server CPU Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 5,
+        "y": 85
+      },
+      "id": 204,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 96,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server RAM Usage",
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 10,
+        "y": 85
+      },
+      "id": 205,
+      "links": [],
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 45,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_name",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "sppcatalog",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "percentUsed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Catalog Space",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Duration of the last execution of selected jobs",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No Execution Recorded",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 36000000
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 85
+      },
+      "id": 206,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 136,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_jobName",
+          "groupBy": [
+            {
+              "params": [
+                "jobName"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Housekeeping-Job Durations",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 92
+      },
+      "hiddenSeries": false,
+      "id": 207,
+      "interval": "",
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 44,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "CPU-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "RAM-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "*100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU / RAM SPP-Server (REST)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:39939",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:39940",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": 10
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 92
+      },
+      "id": 208,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 139,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Maintenance",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 92
+      },
+      "id": 209,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 140,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Hypervisor Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 92
+      },
+      "id": 210,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 138,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "=",
+              "value": "COMPLETED"
+            },
+            {
+              "condition": "AND",
+              "key": "subPolicyType",
+              "operator": "=",
+              "value": "BACKUP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Catalog Backup",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 92
+      },
+      "id": 211,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 141,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Storage Server Inventory",
+      "type": "stat"
+    },
+    {
       "datasource": null,
       "fieldConfig": {
         "defaults": {
@@ -6249,12 +10141,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 10,
         "w": 4,
-        "x": 16,
-        "y": 60
+        "x": 8,
+        "y": 95
       },
-      "id": 180,
+      "id": 212,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -6269,15 +10161,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 98,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
         }
       },
       "targets": [
@@ -6339,6 +10231,742 @@
       "type": "stat"
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 95
+      },
+      "hiddenSeries": false,
+      "id": 213,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 93,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "max": 50,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 95
+      },
+      "id": 214,
+      "interval": "24h",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 142,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "--constant",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.\"rp_days_14\".\"sppmon_metrics\" WHERE $timeFilter AND (\"constant\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--hourly",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"hourly\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--daily",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"daily\" = 'True'))  GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--all",
+          "groupBy": [],
+          "limit": "",
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"all\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "all",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "others",
+          "groupBy": [],
+          "hide": true,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"daily\" != 'True' AND \"constant\" != 'True' AND \"all\" != 'True' AND \"hourly\" != 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "constant",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "all",
+              "operator": "!=",
+              "value": "True"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPPmon Collection Errors (24h)",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "light-orange",
+                "value": 36000000
+              },
+              {
+                "color": "#d44a3a",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 95
+      },
+      "id": 215,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 128,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Catalog Backup Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h per Commandgroup",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 800,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 99
+      },
+      "id": 216,
+      "interval": "",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 97,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%CPU\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER') GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%CPU"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP-Server Processes CPU Usage ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 99
+      },
+      "id": 217,
+      "interval": "1h",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 99,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%MEM\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER')  GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%MEM"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Process RAM Usage",
+      "type": "bargauge"
+    },
+    {
       "cacheTimeout": null,
       "datasource": null,
       "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
@@ -6365,9 +10993,9 @@
         "h": 6,
         "w": 4,
         "x": 20,
-        "y": 60
+        "y": 99
       },
-      "id": 181,
+      "id": 218,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -6385,15 +11013,15 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 125,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
         }
       },
       "targets": [
@@ -6426,7 +11054,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
         },
         {
           "alias": "Backuped Bytes",
@@ -6457,7 +11091,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
         }
       ],
       "timeFrom": null,
@@ -6491,9 +11131,9 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 63
+        "y": 102
       },
-      "id": 182,
+      "id": 219,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -6508,16 +11148,16 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "repeatDirection": "h",
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 144,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "scaleVM10v2",
-          "value": "scaleVM10v2"
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
         }
       },
       "targets": [
@@ -6560,18 +11200,114 @@
       "type": "stat"
     },
     {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 102
+      },
+      "id": 220,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dev_tucson_new",
+          "value": "dev_tucson_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 105
       },
-      "id": 183,
+      "id": 221,
       "panels": [],
-      "repeat": null,
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 60,
       "scopedVars": {
         "SPP_Server": {
@@ -6619,9 +11355,9 @@
         "h": 7,
         "w": 5,
         "x": 0,
-        "y": 67
+        "y": 106
       },
-      "id": 184,
+      "id": 222,
       "interval": "",
       "options": {
         "orientation": "auto",
@@ -6635,8 +11371,8 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 95,
       "repeatedByRow": true,
       "scopedVars": {
@@ -6723,9 +11459,9 @@
         "h": 7,
         "w": 5,
         "x": 5,
-        "y": 67
+        "y": 106
       },
-      "id": 185,
+      "id": 223,
       "options": {
         "orientation": "auto",
         "reduceOptions": {
@@ -6738,8 +11474,8 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 96,
       "repeatedByRow": true,
       "scopedVars": {
@@ -6792,7 +11528,7 @@
     {
       "cacheTimeout": null,
       "datasource": null,
-      "description": "95% Percentille / last 24h of each component memory usage",
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -6823,11 +11559,11 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 4,
+        "w": 5,
         "x": 10,
-        "y": 67
+        "y": 106
       },
-      "id": 186,
+      "id": 224,
       "links": [],
       "options": {
         "displayMode": "lcd",
@@ -6841,8 +11577,8 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 45,
       "repeatedByRow": true,
       "scopedVars": {
@@ -6891,6 +11627,61 @@
             ]
           ],
           "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
         }
       ],
       "timeFrom": null,
@@ -6941,11 +11732,11 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 10,
-        "x": 14,
-        "y": 67
+        "w": 9,
+        "x": 15,
+        "y": 106
       },
-      "id": 187,
+      "id": 225,
       "links": [],
       "options": {
         "colorMode": "value",
@@ -6961,8 +11752,8 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 136,
       "repeatedByRow": true,
       "scopedVars": {
@@ -7042,13 +11833,13 @@
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
         "x": 0,
-        "y": 74
+        "y": 113
       },
       "hiddenSeries": false,
-      "id": 188,
+      "id": 226,
       "interval": "",
       "legend": {
         "alignAsTable": false,
@@ -7065,12 +11856,15 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
@@ -7230,12 +12024,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 8,
-        "y": 74
+        "y": 113
       },
-      "id": 189,
+      "id": 227,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -7250,8 +12044,8 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 139,
       "repeatedByRow": true,
       "scopedVars": {
@@ -7320,12 +12114,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 12,
-        "y": 74
+        "y": 113
       },
-      "id": 190,
+      "id": 228,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -7340,8 +12134,8 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 140,
       "repeatedByRow": true,
       "scopedVars": {
@@ -7410,12 +12204,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 16,
-        "y": 74
+        "y": 113
       },
-      "id": 191,
+      "id": 229,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -7430,8 +12224,8 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 138,
       "repeatedByRow": true,
       "scopedVars": {
@@ -7512,12 +12306,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 20,
-        "y": 74
+        "y": 113
       },
-      "id": 192,
+      "id": 230,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -7532,8 +12326,8 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 141,
       "repeatedByRow": true,
       "scopedVars": {
@@ -7583,6 +12377,287 @@
     },
     {
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 116
+      },
+      "id": 231,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 98,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 116
+      },
+      "hiddenSeries": false,
+      "id": 232,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 93,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
       "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
       "fieldConfig": {
         "defaults": {
@@ -7608,12 +12683,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 7,
         "w": 4,
-        "x": 8,
-        "y": 78
+        "x": 16,
+        "y": 116
       },
-      "id": 193,
+      "id": 233,
       "interval": "24h",
       "options": {
         "orientation": "auto",
@@ -7627,8 +12702,8 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 142,
       "repeatedByRow": true,
       "scopedVars": {
@@ -7822,6 +12897,1872 @@
       "type": "gauge"
     },
     {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "light-orange",
+                "value": 36000000
+              },
+              {
+                "color": "#d44a3a",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 116
+      },
+      "id": 234,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 128,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Catalog Backup Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h per Commandgroup",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 800,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 120
+      },
+      "id": 235,
+      "interval": "",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 97,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%CPU\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER') GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%CPU"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP-Server Processes CPU Usage ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 120
+      },
+      "id": 236,
+      "interval": "1h",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 99,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%MEM\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER')  GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%MEM"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Process RAM Usage",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 120
+      },
+      "id": 237,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 125,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Replicated Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmReplicateStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "replicatedBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
+        },
+        {
+          "alias": "Backuped Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmBackupSummary",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "transferredBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VM Statistics (Total of last 24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 123
+      },
+      "id": 238,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^sppmon_metrics\\.spp_version$/",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 144,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "spp_version"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Version",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 123
+      },
+      "id": 239,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 126
+      },
+      "id": 240,
+      "panels": [],
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 60,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "title": "$SPP_Server Overview",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 127
+      },
+      "id": 241,
+      "interval": "",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 95,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT percentile(\"cpuUtil\", 90) FROM \"rp_days_14\".\"cpuram\" WHERE $timeFilter GROUP BY time(24h)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server CPU Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 5,
+        "y": 127
+      },
+      "id": 242,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 96,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server RAM Usage",
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 10,
+        "y": 127
+      },
+      "id": 243,
+      "links": [],
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 45,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_name",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "sppcatalog",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "percentUsed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Catalog Space",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Duration of the last execution of selected jobs",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No Execution Recorded",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 36000000
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 127
+      },
+      "id": 244,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 136,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_jobName",
+          "groupBy": [
+            {
+              "params": [
+                "jobName"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Housekeeping-Job Durations",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 134
+      },
+      "hiddenSeries": false,
+      "id": 245,
+      "interval": "",
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 44,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "CPU-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "RAM-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "*100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU / RAM SPP-Server (REST)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:39939",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:39940",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": 10
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 134
+      },
+      "id": 246,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 139,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Maintenance",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 134
+      },
+      "id": 247,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 140,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Hypervisor Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 134
+      },
+      "id": 248,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 138,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "=",
+              "value": "COMPLETED"
+            },
+            {
+              "condition": "AND",
+              "key": "subPolicyType",
+              "operator": "=",
+              "value": "BACKUP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Catalog Backup",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 134
+      },
+      "id": 249,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 141,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Storage Server Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 137
+      },
+      "id": 250,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 98,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -7839,10 +14780,10 @@
         "h": 7,
         "w": 4,
         "x": 12,
-        "y": 78
+        "y": 137
       },
       "hiddenSeries": false,
-      "id": 194,
+      "id": 251,
       "legend": {
         "avg": false,
         "current": false,
@@ -7855,20 +14796,23 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 93,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
         }
       },
       "seriesOverrides": [],
@@ -7979,6 +14923,246 @@
       }
     },
     {
+      "datasource": null,
+      "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "max": 50,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 137
+      },
+      "id": 252,
+      "interval": "24h",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 142,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "--constant",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.\"rp_days_14\".\"sppmon_metrics\" WHERE $timeFilter AND (\"constant\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--hourly",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"hourly\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--daily",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"daily\" = 'True'))  GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--all",
+          "groupBy": [],
+          "limit": "",
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"all\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "all",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "others",
+          "groupBy": [],
+          "hide": true,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"daily\" != 'True' AND \"constant\" != 'True' AND \"all\" != 'True' AND \"hourly\" != 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "constant",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "all",
+              "operator": "!=",
+              "value": "True"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPPmon Collection Errors (24h)",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
       "cacheTimeout": null,
       "datasource": null,
       "description": "",
@@ -8013,10 +15197,10 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 16,
-        "y": 78
+        "x": 20,
+        "y": 137
       },
-      "id": 195,
+      "id": 253,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -8034,15 +15218,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 128,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
         }
       },
       "targets": [
@@ -8076,103 +15260,6 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Catalog Backup Duration",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "noValue": "N/A",
-          "nullValueMode": "connected",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 78
-      },
-      "id": 196,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
-      "repeatPanelId": 143,
-      "repeatedByRow": true,
-      "scopedVars": {
-        "SPP_Server": {
-          "selected": false,
-          "text": "default",
-          "value": "default"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Catalog Backup",
-          "groupBy": [
-            {
-              "params": [
-                "24h"
-              ],
-              "type": "time"
-            }
-          ],
-          "measurement": "jobs",
-          "orderByTime": "ASC",
-          "policy": "$SPP_Server\".\"rp_days_90",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "jobLogsCount"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Job Logs Stored 24h",
       "type": "stat"
     },
     {
@@ -8211,9 +15298,9 @@
         "h": 6,
         "w": 4,
         "x": 0,
-        "y": 82
+        "y": 141
       },
-      "id": 197,
+      "id": 254,
       "interval": "",
       "options": {
         "displayMode": "lcd",
@@ -8227,15 +15314,15 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
         }
       },
       "targets": [
@@ -8329,9 +15416,9 @@
         "h": 6,
         "w": 4,
         "x": 4,
-        "y": 82
+        "y": 141
       },
-      "id": 198,
+      "id": 255,
       "interval": "1h",
       "options": {
         "displayMode": "lcd",
@@ -8345,15 +15432,15 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 99,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
         }
       },
       "targets": [
@@ -8412,6 +15499,1415 @@
       "type": "bargauge"
     },
     {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 141
+      },
+      "id": 256,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 125,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Replicated Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmReplicateStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "replicatedBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
+        },
+        {
+          "alias": "Backuped Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmBackupSummary",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "transferredBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VM Statistics (Total of last 24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 144
+      },
+      "id": 257,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^sppmon_metrics\\.spp_version$/",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 144,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "spp_version"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Version",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 144
+      },
+      "id": 258,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "devSPPv2 EXTERNAL",
+          "value": "devSPPv2 EXTERNAL"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 147
+      },
+      "id": 259,
+      "panels": [],
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 60,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "title": "$SPP_Server Overview",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 148
+      },
+      "id": 260,
+      "interval": "",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 95,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT percentile(\"cpuUtil\", 90) FROM \"rp_days_14\".\"cpuram\" WHERE $timeFilter GROUP BY time(24h)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server CPU Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 5,
+        "y": 148
+      },
+      "id": 261,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 96,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server RAM Usage",
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 10,
+        "y": 148
+      },
+      "id": 262,
+      "links": [],
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 45,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_name",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "sppcatalog",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "percentUsed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Catalog Space",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Duration of the last execution of selected jobs",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No Execution Recorded",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 36000000
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 148
+      },
+      "id": 263,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 136,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_jobName",
+          "groupBy": [
+            {
+              "params": [
+                "jobName"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Housekeeping-Job Durations",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 155
+      },
+      "hiddenSeries": false,
+      "id": 264,
+      "interval": "",
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 44,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "CPU-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "RAM-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "*100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU / RAM SPP-Server (REST)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:39939",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:39940",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": 10
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 155
+      },
+      "id": 265,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 139,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Maintenance",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 155
+      },
+      "id": 266,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 140,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Hypervisor Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 155
+      },
+      "id": 267,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 138,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "=",
+              "value": "COMPLETED"
+            },
+            {
+              "condition": "AND",
+              "key": "subPolicyType",
+              "operator": "=",
+              "value": "BACKUP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Catalog Backup",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 155
+      },
+      "id": 268,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 141,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Storage Server Inventory",
+      "type": "stat"
+    },
+    {
       "datasource": null,
       "fieldConfig": {
         "defaults": {
@@ -8443,12 +16939,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 10,
         "w": 4,
-        "x": 16,
-        "y": 82
+        "x": 8,
+        "y": 158
       },
-      "id": 199,
+      "id": 269,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -8463,15 +16959,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 98,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
         }
       },
       "targets": [
@@ -8533,6 +17029,742 @@
       "type": "stat"
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 158
+      },
+      "hiddenSeries": false,
+      "id": 270,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 93,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "max": 50,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 158
+      },
+      "id": 271,
+      "interval": "24h",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 142,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "--constant",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.\"rp_days_14\".\"sppmon_metrics\" WHERE $timeFilter AND (\"constant\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--hourly",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"hourly\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--daily",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"daily\" = 'True'))  GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--all",
+          "groupBy": [],
+          "limit": "",
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"all\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "all",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "others",
+          "groupBy": [],
+          "hide": true,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"daily\" != 'True' AND \"constant\" != 'True' AND \"all\" != 'True' AND \"hourly\" != 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "constant",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "all",
+              "operator": "!=",
+              "value": "True"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPPmon Collection Errors (24h)",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "light-orange",
+                "value": 36000000
+              },
+              {
+                "color": "#d44a3a",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 158
+      },
+      "id": 272,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 128,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Catalog Backup Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h per Commandgroup",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 800,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 162
+      },
+      "id": 273,
+      "interval": "",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 97,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%CPU\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER') GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%CPU"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP-Server Processes CPU Usage ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 162
+      },
+      "id": 274,
+      "interval": "1h",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 99,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%MEM\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER')  GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%MEM"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Process RAM Usage",
+      "type": "bargauge"
+    },
+    {
       "cacheTimeout": null,
       "datasource": null,
       "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
@@ -8559,9 +17791,9 @@
         "h": 6,
         "w": 4,
         "x": 20,
-        "y": 82
+        "y": 162
       },
-      "id": 200,
+      "id": 275,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -8579,15 +17811,15 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.1.3",
-      "repeatIteration": 1601761461271,
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 125,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
         }
       },
       "targets": [
@@ -8620,7 +17852,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
         },
         {
           "alias": "Backuped Bytes",
@@ -8651,7 +17889,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
         }
       ],
       "timeFrom": null,
@@ -8685,9 +17929,9 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 85
+        "y": 165
       },
-      "id": 201,
+      "id": 276,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -8702,16 +17946,16 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.3",
+      "pluginVersion": "7.3.3",
       "repeatDirection": "h",
-      "repeatIteration": 1601761461271,
+      "repeatIteration": 1611415376873,
       "repeatPanelId": 144,
       "repeatedByRow": true,
       "scopedVars": {
         "SPP_Server": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
         }
       },
       "targets": [
@@ -8752,6 +17996,11433 @@
       "timeShift": null,
       "title": "SPP Version",
       "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 165
+      },
+      "id": 277,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dmw_202_new",
+          "value": "dmw_202_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 168
+      },
+      "id": 278,
+      "panels": [],
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 60,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "title": "$SPP_Server Overview",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 169
+      },
+      "id": 279,
+      "interval": "",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 95,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT percentile(\"cpuUtil\", 90) FROM \"rp_days_14\".\"cpuram\" WHERE $timeFilter GROUP BY time(24h)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server CPU Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 5,
+        "y": 169
+      },
+      "id": 280,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 96,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server RAM Usage",
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 10,
+        "y": 169
+      },
+      "id": 281,
+      "links": [],
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 45,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_name",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "sppcatalog",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "percentUsed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Catalog Space",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Duration of the last execution of selected jobs",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No Execution Recorded",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 36000000
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 169
+      },
+      "id": 282,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 136,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_jobName",
+          "groupBy": [
+            {
+              "params": [
+                "jobName"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Housekeeping-Job Durations",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 176
+      },
+      "hiddenSeries": false,
+      "id": 283,
+      "interval": "",
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 44,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "CPU-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "RAM-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "*100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU / RAM SPP-Server (REST)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:39939",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:39940",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": 10
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 176
+      },
+      "id": 284,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 139,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Maintenance",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 176
+      },
+      "id": 285,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 140,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Hypervisor Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 176
+      },
+      "id": 286,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 138,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "=",
+              "value": "COMPLETED"
+            },
+            {
+              "condition": "AND",
+              "key": "subPolicyType",
+              "operator": "=",
+              "value": "BACKUP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Catalog Backup",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 176
+      },
+      "id": 287,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 141,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Storage Server Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 179
+      },
+      "id": 288,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 98,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 179
+      },
+      "hiddenSeries": false,
+      "id": 289,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 93,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "max": 50,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 179
+      },
+      "id": 290,
+      "interval": "24h",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 142,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "--constant",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.\"rp_days_14\".\"sppmon_metrics\" WHERE $timeFilter AND (\"constant\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--hourly",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"hourly\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--daily",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"daily\" = 'True'))  GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--all",
+          "groupBy": [],
+          "limit": "",
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"all\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "all",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "others",
+          "groupBy": [],
+          "hide": true,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"daily\" != 'True' AND \"constant\" != 'True' AND \"all\" != 'True' AND \"hourly\" != 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "constant",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "all",
+              "operator": "!=",
+              "value": "True"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPPmon Collection Errors (24h)",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "light-orange",
+                "value": 36000000
+              },
+              {
+                "color": "#d44a3a",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 179
+      },
+      "id": 291,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 128,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Catalog Backup Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h per Commandgroup",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 800,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 183
+      },
+      "id": 292,
+      "interval": "",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 97,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%CPU\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER') GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%CPU"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP-Server Processes CPU Usage ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 183
+      },
+      "id": 293,
+      "interval": "1h",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 99,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%MEM\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER')  GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%MEM"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Process RAM Usage",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 183
+      },
+      "id": 294,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 125,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Replicated Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmReplicateStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "replicatedBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
+        },
+        {
+          "alias": "Backuped Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmBackupSummary",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "transferredBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VM Statistics (Total of last 24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 186
+      },
+      "id": 295,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^sppmon_metrics\\.spp_version$/",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 144,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "spp_version"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Version",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 186
+      },
+      "id": 296,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "dpr_sle_srv_new",
+          "value": "dpr_sle_srv_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 189
+      },
+      "id": 297,
+      "panels": [],
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 60,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "title": "$SPP_Server Overview",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 190
+      },
+      "id": 298,
+      "interval": "",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 95,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT percentile(\"cpuUtil\", 90) FROM \"rp_days_14\".\"cpuram\" WHERE $timeFilter GROUP BY time(24h)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server CPU Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 5,
+        "y": 190
+      },
+      "id": 299,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 96,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server RAM Usage",
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 10,
+        "y": 190
+      },
+      "id": 300,
+      "links": [],
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 45,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_name",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "sppcatalog",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "percentUsed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Catalog Space",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Duration of the last execution of selected jobs",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No Execution Recorded",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 36000000
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 190
+      },
+      "id": 301,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 136,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_jobName",
+          "groupBy": [
+            {
+              "params": [
+                "jobName"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Housekeeping-Job Durations",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 197
+      },
+      "hiddenSeries": false,
+      "id": 302,
+      "interval": "",
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 44,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "CPU-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "RAM-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "*100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU / RAM SPP-Server (REST)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:39939",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:39940",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": 10
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 197
+      },
+      "id": 303,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 139,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Maintenance",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 197
+      },
+      "id": 304,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 140,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Hypervisor Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 197
+      },
+      "id": 305,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 138,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "=",
+              "value": "COMPLETED"
+            },
+            {
+              "condition": "AND",
+              "key": "subPolicyType",
+              "operator": "=",
+              "value": "BACKUP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Catalog Backup",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 197
+      },
+      "id": 306,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 141,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Storage Server Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 200
+      },
+      "id": 307,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 98,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 200
+      },
+      "hiddenSeries": false,
+      "id": 308,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 93,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "max": 50,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 200
+      },
+      "id": 309,
+      "interval": "24h",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 142,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "--constant",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.\"rp_days_14\".\"sppmon_metrics\" WHERE $timeFilter AND (\"constant\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--hourly",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"hourly\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--daily",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"daily\" = 'True'))  GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--all",
+          "groupBy": [],
+          "limit": "",
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"all\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "all",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "others",
+          "groupBy": [],
+          "hide": true,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"daily\" != 'True' AND \"constant\" != 'True' AND \"all\" != 'True' AND \"hourly\" != 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "constant",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "all",
+              "operator": "!=",
+              "value": "True"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPPmon Collection Errors (24h)",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "light-orange",
+                "value": 36000000
+              },
+              {
+                "color": "#d44a3a",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 200
+      },
+      "id": 310,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 128,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Catalog Backup Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h per Commandgroup",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 800,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 204
+      },
+      "id": 311,
+      "interval": "",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 97,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%CPU\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER') GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%CPU"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP-Server Processes CPU Usage ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 204
+      },
+      "id": 312,
+      "interval": "1h",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 99,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%MEM\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER')  GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%MEM"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Process RAM Usage",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 204
+      },
+      "id": 313,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 125,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Replicated Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmReplicateStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "replicatedBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
+        },
+        {
+          "alias": "Backuped Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmBackupSummary",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "transferredBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VM Statistics (Total of last 24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 207
+      },
+      "id": 314,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^sppmon_metrics\\.spp_version$/",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 144,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "spp_version"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Version",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 207
+      },
+      "id": 315,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2",
+          "value": "scaleVM10v2"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 210
+      },
+      "id": 316,
+      "panels": [],
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 60,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "title": "$SPP_Server Overview",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 211
+      },
+      "id": 317,
+      "interval": "",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 95,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT percentile(\"cpuUtil\", 90) FROM \"rp_days_14\".\"cpuram\" WHERE $timeFilter GROUP BY time(24h)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server CPU Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 5,
+        "y": 211
+      },
+      "id": 318,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 96,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server RAM Usage",
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 10,
+        "y": 211
+      },
+      "id": 319,
+      "links": [],
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 45,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_name",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "sppcatalog",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "percentUsed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Catalog Space",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Duration of the last execution of selected jobs",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No Execution Recorded",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 36000000
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 211
+      },
+      "id": 320,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 136,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_jobName",
+          "groupBy": [
+            {
+              "params": [
+                "jobName"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Housekeeping-Job Durations",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 218
+      },
+      "hiddenSeries": false,
+      "id": 321,
+      "interval": "",
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 44,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "CPU-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "RAM-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "*100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU / RAM SPP-Server (REST)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:39939",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:39940",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": 10
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 218
+      },
+      "id": 322,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 139,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Maintenance",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 218
+      },
+      "id": 323,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 140,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Hypervisor Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 218
+      },
+      "id": 324,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 138,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "=",
+              "value": "COMPLETED"
+            },
+            {
+              "condition": "AND",
+              "key": "subPolicyType",
+              "operator": "=",
+              "value": "BACKUP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Catalog Backup",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 218
+      },
+      "id": 325,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 141,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Storage Server Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 221
+      },
+      "id": 326,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 98,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 221
+      },
+      "hiddenSeries": false,
+      "id": 327,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 93,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "max": 50,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 221
+      },
+      "id": 328,
+      "interval": "24h",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 142,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "--constant",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.\"rp_days_14\".\"sppmon_metrics\" WHERE $timeFilter AND (\"constant\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--hourly",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"hourly\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--daily",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"daily\" = 'True'))  GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--all",
+          "groupBy": [],
+          "limit": "",
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"all\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "all",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "others",
+          "groupBy": [],
+          "hide": true,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"daily\" != 'True' AND \"constant\" != 'True' AND \"all\" != 'True' AND \"hourly\" != 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "constant",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "all",
+              "operator": "!=",
+              "value": "True"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPPmon Collection Errors (24h)",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "light-orange",
+                "value": 36000000
+              },
+              {
+                "color": "#d44a3a",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 221
+      },
+      "id": 329,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 128,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Catalog Backup Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h per Commandgroup",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 800,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 225
+      },
+      "id": 330,
+      "interval": "",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 97,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%CPU\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER') GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%CPU"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP-Server Processes CPU Usage ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 225
+      },
+      "id": 331,
+      "interval": "1h",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 99,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%MEM\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER')  GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%MEM"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Process RAM Usage",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 225
+      },
+      "id": 332,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 125,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Replicated Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmReplicateStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "replicatedBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
+        },
+        {
+          "alias": "Backuped Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmBackupSummary",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "transferredBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VM Statistics (Total of last 24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 228
+      },
+      "id": 333,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^sppmon_metrics\\.spp_version$/",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 144,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "spp_version"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Version",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 228
+      },
+      "id": 334,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "scaleVM10v2 external",
+          "value": "scaleVM10v2 external"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 231
+      },
+      "id": 335,
+      "panels": [],
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 60,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "title": "$SPP_Server Overview",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 232
+      },
+      "id": 336,
+      "interval": "",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 95,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT percentile(\"cpuUtil\", 90) FROM \"rp_days_14\".\"cpuram\" WHERE $timeFilter GROUP BY time(24h)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server CPU Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 5,
+        "y": 232
+      },
+      "id": 337,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 96,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server RAM Usage",
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 10,
+        "y": 232
+      },
+      "id": 338,
+      "links": [],
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 45,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_name",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "sppcatalog",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "percentUsed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Catalog Space",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Duration of the last execution of selected jobs",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No Execution Recorded",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 36000000
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 232
+      },
+      "id": 339,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 136,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_jobName",
+          "groupBy": [
+            {
+              "params": [
+                "jobName"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Housekeeping-Job Durations",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 239
+      },
+      "hiddenSeries": false,
+      "id": 340,
+      "interval": "",
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 44,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "CPU-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "RAM-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "*100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU / RAM SPP-Server (REST)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:39939",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:39940",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": 10
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 239
+      },
+      "id": 341,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 139,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Maintenance",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 239
+      },
+      "id": 342,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 140,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Hypervisor Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 239
+      },
+      "id": 343,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 138,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "=",
+              "value": "COMPLETED"
+            },
+            {
+              "condition": "AND",
+              "key": "subPolicyType",
+              "operator": "=",
+              "value": "BACKUP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Catalog Backup",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 239
+      },
+      "id": 344,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 141,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Storage Server Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 242
+      },
+      "id": 345,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 98,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 242
+      },
+      "hiddenSeries": false,
+      "id": 346,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 93,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "max": 50,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 242
+      },
+      "id": 347,
+      "interval": "24h",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 142,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "--constant",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.\"rp_days_14\".\"sppmon_metrics\" WHERE $timeFilter AND (\"constant\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--hourly",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"hourly\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--daily",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"daily\" = 'True'))  GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--all",
+          "groupBy": [],
+          "limit": "",
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"all\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "all",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "others",
+          "groupBy": [],
+          "hide": true,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"daily\" != 'True' AND \"constant\" != 'True' AND \"all\" != 'True' AND \"hourly\" != 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "constant",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "all",
+              "operator": "!=",
+              "value": "True"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPPmon Collection Errors (24h)",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "light-orange",
+                "value": 36000000
+              },
+              {
+                "color": "#d44a3a",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 242
+      },
+      "id": 348,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 128,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Catalog Backup Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h per Commandgroup",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 800,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 246
+      },
+      "id": 349,
+      "interval": "",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 97,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%CPU\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER') GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%CPU"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP-Server Processes CPU Usage ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 246
+      },
+      "id": 350,
+      "interval": "1h",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 99,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%MEM\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER')  GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%MEM"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Process RAM Usage",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 246
+      },
+      "id": 351,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 125,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Replicated Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmReplicateStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "replicatedBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
+        },
+        {
+          "alias": "Backuped Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmBackupSummary",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "transferredBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VM Statistics (Total of last 24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 249
+      },
+      "id": 352,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^sppmon_metrics\\.spp_version$/",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 144,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "spp_version"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Version",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 249
+      },
+      "id": 353,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "spppod2_vm17",
+          "value": "spppod2_vm17"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 252
+      },
+      "id": 354,
+      "panels": [],
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 60,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "title": "$SPP_Server Overview",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 253
+      },
+      "id": 355,
+      "interval": "",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 95,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT percentile(\"cpuUtil\", 90) FROM \"rp_days_14\".\"cpuram\" WHERE $timeFilter GROUP BY time(24h)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server CPU Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% Percentille over last 24h ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 5,
+        "y": 253
+      },
+      "id": 356,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 96,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server RAM Usage",
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 10,
+        "y": 253
+      },
+      "id": 357,
+      "links": [],
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 45,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_name",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "sppcatalog",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "percentUsed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Catalog Space",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Duration of the last execution of selected jobs",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No Execution Recorded",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 36000000
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 253
+      },
+      "id": 358,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 136,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_jobName",
+          "groupBy": [
+            {
+              "params": [
+                "jobName"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            },
+            {
+              "condition": "OR",
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Housekeeping-Job Durations",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 260
+      },
+      "hiddenSeries": false,
+      "id": 359,
+      "interval": "",
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 44,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "CPU-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "cpuUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "RAM-Usage",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cpuram",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "memoryUtil"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "*100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU / RAM SPP-Server (REST)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:39939",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:39940",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": 10
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 260
+      },
+      "id": 360,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 139,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Maintenance"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Maintenance",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 260
+      },
+      "id": 361,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 140,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Hypervisor Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Hypervisor Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 260
+      },
+      "id": 362,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 138,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            },
+            {
+              "condition": "AND",
+              "key": "status",
+              "operator": "=",
+              "value": "COMPLETED"
+            },
+            {
+              "condition": "AND",
+              "key": "subPolicyType",
+              "operator": "=",
+              "value": "BACKUP"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Catalog Backup",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "Not Executed",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 260
+      },
+      "id": 363,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 141,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "end"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "*1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=",
+              "value": "Storage Server Inventory"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Storage Server Inventory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 263
+      },
+      "id": 364,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 98,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 263
+      },
+      "hiddenSeries": false,
+      "id": 365,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 93,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Total",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCount"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Protected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountProtected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Unprotected",
+          "groupBy": [],
+          "measurement": "vmStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "vmCountUnprotected"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VM Statistics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "max": 50,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 263
+      },
+      "id": 366,
+      "interval": "24h",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 142,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "--constant",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.\"rp_days_14\".\"sppmon_metrics\" WHERE $timeFilter AND (\"constant\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--hourly",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"hourly\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "constant",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--daily",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE $timeFilter AND (\"daily\" = 'True'))  GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "--all",
+          "groupBy": [],
+          "limit": "",
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"all\" = 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "all",
+              "operator": "=",
+              "value": "True"
+            }
+          ]
+        },
+        {
+          "alias": "others",
+          "groupBy": [],
+          "hide": true,
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(*) FROM (SELECT non_negative_difference(\"errorCount\") FROM $SPP_Server.rp_days_14.\"sppmon_metrics\" WHERE  $timeFilter AND (\"daily\" != 'True' AND \"constant\" != 'True' AND \"all\" != 'True' AND \"hourly\" != 'True')) GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "errorCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "daily",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "constant",
+              "operator": "!=",
+              "value": "True"
+            },
+            {
+              "condition": "AND",
+              "key": "all",
+              "operator": "!=",
+              "value": "True"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPPmon Collection Errors (24h)",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "light-orange",
+                "value": 36000000
+              },
+              {
+                "color": "#d44a3a",
+                "value": 72000000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 263
+      },
+      "id": 367,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 128,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "jobName",
+              "operator": "=~",
+              "value": "/.*catalog.*/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Catalog Backup Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h per Commandgroup",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 800,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 267
+      },
+      "id": 368,
+      "interval": "",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 97,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%CPU\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER') GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%CPU"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP-Server Processes CPU Usage ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "description": "95% percentille of last 24h",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 267
+      },
+      "id": 369,
+      "interval": "1h",
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 99,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_COMMAND",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "COMMAND"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "processStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "query": "SELECT PERCENTILE( *, 90) FROM (SELECT sum(\"%MEM\") FROM \"$SPP_Server\".\"rp_days_14\".\"processStats\" WHERE $timeFilter AND  (\"ssh_type\" = 'SERVER')  GROUP BY time(1s), \"COMMAND\") GROUP BY time($interval), \"COMMAND\"  fill(none)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%MEM"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "90"
+                ],
+                "type": "percentile"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "COMMAND",
+              "operator": "!=",
+              "value": "mongodump"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Process RAM Usage",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "Sum of replicated bytes within the last 24h\nSum of transferred bytes within the last 24h\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 267
+      },
+      "id": 370,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 125,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Replicated Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmReplicateStats",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "replicatedBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA0398"
+            }
+          ]
+        },
+        {
+          "alias": "Backuped Bytes",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "vmBackupSummary",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_14",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "transferredBytes"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "messageId",
+              "operator": "=",
+              "value": "CTGGA2384"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VM Statistics (Total of last 24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 270
+      },
+      "id": 371,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^sppmon_metrics\\.spp_version$/",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatDirection": "h",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 144,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [],
+          "measurement": "sppmon_metrics",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "spp_version"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Version",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 270
+      },
+      "id": 372,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "repeatIteration": 1611415376873,
+      "repeatPanelId": 143,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "SPP_Server": {
+          "selected": false,
+          "text": "tulipa_new",
+          "value": "tulipa_new"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Catalog Backup",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "$SPP_Server\".\"rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
+      "type": "stat"
     }
   ],
   "refresh": "15m",
@@ -8763,11 +29434,15 @@
       {
         "current": {
           "selected": true,
-          "text": "All",
+          "tags": [],
+          "text": [
+            "All"
+          ],
           "value": [
             "$__all"
           ]
         },
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Repeat Row for ",
@@ -8802,5 +29477,5 @@
   "timezone": "",
   "title": "Multiple Server Overview",
   "uid": "GtH9VNSMz",
-  "version": 2
+  "version": 11
 }

--- a/Grafana/SPPMON Long Term View (90 Days _ Infinite).json
+++ b/Grafana/SPPMON Long Term View (90 Days _ Infinite).json
@@ -18,7 +18,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 30,
-  "iteration": 1609280991251,
+  "iteration": 1611415756956,
   "links": [],
   "panels": [
     {
@@ -53,7 +53,7 @@
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 8,
         "x": 0,
         "y": 1
@@ -317,7 +317,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 8,
         "x": 16,
         "y": 1
@@ -452,7 +452,147 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 98,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "1d"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "$rp",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$SPP_Server",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
         "w": 8,
         "x": 8,
         "y": 9
@@ -589,146 +729,6 @@
     {
       "aliasColors": {},
       "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 11
-      },
-      "hiddenSeries": false,
-      "id": 98,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "$tag_ssh_type",
-          "groupBy": [
-            {
-              "params": [
-                "1d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "ssh_type"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "ssh_mpstat_cmd",
-          "orderByTime": "ASC",
-          "policy": "$rp",
-          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "%idle"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "min"
-              },
-              {
-                "params": [
-                  "*-1 + 100"
-                ],
-                "type": "math"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Highest CPU load by Component",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
@@ -743,10 +743,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
         "x": 16,
-        "y": 11
+        "y": 9
       },
       "hiddenSeries": false,
       "id": 128,
@@ -849,6 +849,146 @@
     {
       "aliasColors": {},
       "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$SPP_Server",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 155,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "1d"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_free_cmd",
+          "orderByTime": "ASC",
+          "policy": "$rp",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "used"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              },
+              {
+                "params": [
+                  " / total"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Highest RAM load by Component",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
@@ -863,10 +1003,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
         "x": 8,
-        "y": 17
+        "y": 16
       },
       "hiddenSeries": false,
       "id": 125,
@@ -1031,146 +1171,6 @@
     {
       "aliasColors": {},
       "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 18
-      },
-      "hiddenSeries": false,
-      "id": 155,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "$tag_ssh_type",
-          "groupBy": [
-            {
-              "params": [
-                "1d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "ssh_type"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "ssh_free_cmd",
-          "orderByTime": "ASC",
-          "policy": "$rp",
-          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "used"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              },
-              {
-                "params": [
-                  " / total"
-                ],
-                "type": "math"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Highest RAM load by Component",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
@@ -1185,10 +1185,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
+        "h": 7,
         "w": 8,
         "x": 16,
-        "y": 19
+        "y": 16
       },
       "hiddenSeries": false,
       "id": 150,
@@ -1306,7 +1306,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 23
       },
       "id": 112,
       "panels": [],
@@ -1343,7 +1343,7 @@
         "h": 9,
         "w": 14,
         "x": 0,
-        "y": 26
+        "y": 24
       },
       "hiddenSeries": false,
       "id": 107,
@@ -1608,7 +1608,7 @@
         "h": 9,
         "w": 10,
         "x": 14,
-        "y": 26
+        "y": 24
       },
       "id": 154,
       "options": {
@@ -1739,7 +1739,7 @@
         "h": 9,
         "w": 14,
         "x": 0,
-        "y": 35
+        "y": 33
       },
       "hiddenSeries": false,
       "id": 108,
@@ -2004,7 +2004,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 42
       },
       "id": 89,
       "panels": [],
@@ -2031,7 +2031,7 @@
         "h": 14,
         "w": 13,
         "x": 0,
-        "y": 45
+        "y": 43
       },
       "hiddenSeries": false,
       "id": 115,
@@ -2178,7 +2178,7 @@
         "h": 14,
         "w": 11,
         "x": 13,
-        "y": 45
+        "y": 43
       },
       "hiddenSeries": false,
       "id": 46,
@@ -2329,7 +2329,7 @@
         "h": 15,
         "w": 7,
         "x": 0,
-        "y": 59
+        "y": 57
       },
       "hiddenSeries": false,
       "id": 52,
@@ -2470,7 +2470,7 @@
         "h": 15,
         "w": 6,
         "x": 7,
-        "y": 59
+        "y": 57
       },
       "hiddenSeries": false,
       "id": 50,
@@ -2622,7 +2622,7 @@
         "h": 15,
         "w": 7,
         "x": 13,
-        "y": 59
+        "y": 57
       },
       "hiddenSeries": false,
       "id": 47,
@@ -2773,7 +2773,7 @@
         "h": 15,
         "w": 4,
         "x": 20,
-        "y": 59
+        "y": 57
       },
       "hiddenSeries": false,
       "id": 63,
@@ -2916,9 +2916,9 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 14,
-        "w": 10,
+        "w": 8,
         "x": 0,
-        "y": 74
+        "y": 72
       },
       "hiddenSeries": false,
       "id": 82,
@@ -3022,6 +3022,7 @@
     {
       "aliasColors": {},
       "bars": false,
+      "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
@@ -3035,9 +3036,168 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 14,
-        "w": 10,
-        "x": 10,
-        "y": 74
+        "w": 7,
+        "x": 8,
+        "y": 72
+      },
+      "hiddenSeries": false,
+      "id": 167,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$tag_ssh_type: $tag_hostName on \"$tag_Mounted\"",
+          "groupBy": [
+            {
+              "params": [
+                "$interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "hostName"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "$rp",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Storage Usage (Server & vSnap)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:6623",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:6624",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$SPP_Server",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 9,
+        "x": 15,
+        "y": 72
       },
       "hiddenSeries": false,
       "id": 54,
@@ -3175,7 +3335,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 88
+        "y": 86
       },
       "id": 58,
       "panels": [],
@@ -3200,7 +3360,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 89
+        "y": 87
       },
       "hiddenSeries": false,
       "id": 16,
@@ -3327,7 +3487,7 @@
         "h": 12,
         "w": 6,
         "x": 12,
-        "y": 89
+        "y": 87
       },
       "hiddenSeries": false,
       "id": 19,
@@ -3449,7 +3609,7 @@
         "h": 12,
         "w": 6,
         "x": 18,
-        "y": 89
+        "y": 87
       },
       "hiddenSeries": false,
       "id": 18,
@@ -3571,7 +3731,7 @@
         "h": 12,
         "w": 6,
         "x": 0,
-        "y": 101
+        "y": 99
       },
       "hiddenSeries": false,
       "id": 87,
@@ -3700,7 +3860,7 @@
         "h": 12,
         "w": 6,
         "x": 6,
-        "y": 101
+        "y": 99
       },
       "hiddenSeries": false,
       "id": 66,
@@ -3841,7 +4001,7 @@
         "h": 12,
         "w": 6,
         "x": 12,
-        "y": 101
+        "y": 99
       },
       "hiddenSeries": false,
       "id": 68,
@@ -3963,7 +4123,7 @@
         "h": 12,
         "w": 6,
         "x": 18,
-        "y": 101
+        "y": 99
       },
       "hiddenSeries": false,
       "id": 67,
@@ -4098,7 +4258,7 @@
         "h": 12,
         "w": 6,
         "x": 0,
-        "y": 113
+        "y": 111
       },
       "hiddenSeries": false,
       "id": 133,
@@ -4226,7 +4386,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 125
+        "y": 123
       },
       "id": 158,
       "panels": [],
@@ -4252,7 +4412,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 126
+        "y": 124
       },
       "hiddenSeries": false,
       "id": 160,
@@ -4386,7 +4546,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 126
+        "y": 124
       },
       "hiddenSeries": false,
       "id": 161,
@@ -4560,7 +4720,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 134
+        "y": 132
       },
       "hiddenSeries": false,
       "id": 166,
@@ -4690,7 +4850,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 142
+        "y": 140
       },
       "hiddenSeries": false,
       "id": 164,
@@ -4842,7 +5002,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 150
+        "y": 148
       },
       "hiddenSeries": false,
       "id": 165,
@@ -4995,7 +5155,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 158
+        "y": 156
       },
       "id": 75,
       "panels": [],
@@ -5020,7 +5180,7 @@
         "h": 11,
         "w": 9,
         "x": 0,
-        "y": 159
+        "y": 157
       },
       "hiddenSeries": false,
       "id": 4,
@@ -5174,7 +5334,7 @@
         "h": 11,
         "w": 7,
         "x": 9,
-        "y": 159
+        "y": 157
       },
       "hiddenSeries": false,
       "id": 11,
@@ -5305,7 +5465,7 @@
         "h": 11,
         "w": 8,
         "x": 16,
-        "y": 159
+        "y": 157
       },
       "hiddenSeries": false,
       "id": 6,
@@ -5423,7 +5583,7 @@
         "h": 10,
         "w": 9,
         "x": 0,
-        "y": 170
+        "y": 168
       },
       "hiddenSeries": false,
       "id": 12,
@@ -5583,7 +5743,7 @@
         "h": 10,
         "w": 15,
         "x": 9,
-        "y": 170
+        "y": 168
       },
       "hiddenSeries": false,
       "id": 81,
@@ -5848,7 +6008,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 180
+        "y": 178
       },
       "hiddenSeries": false,
       "id": 84,
@@ -5994,7 +6154,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 180
+        "y": 178
       },
       "hiddenSeries": false,
       "id": 86,
@@ -6160,7 +6320,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 180
+        "y": 178
       },
       "hiddenSeries": false,
       "id": 85,
@@ -6306,7 +6466,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 188
+        "y": 186
       },
       "hiddenSeries": false,
       "id": 104,
@@ -6452,7 +6612,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 188
+        "y": 186
       },
       "hiddenSeries": false,
       "id": 148,
@@ -6598,7 +6758,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 188
+        "y": 186
       },
       "hiddenSeries": false,
       "id": 149,
@@ -6717,7 +6877,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 196
+        "y": 194
       },
       "id": 70,
       "panels": [],
@@ -6742,7 +6902,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 197
+        "y": 195
       },
       "hiddenSeries": false,
       "id": 14,
@@ -6879,7 +7039,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 197
+        "y": 195
       },
       "hiddenSeries": false,
       "id": 71,
@@ -7002,7 +7162,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 205
+        "y": 203
       },
       "hiddenSeries": false,
       "id": 162,
@@ -7139,7 +7299,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 205
+        "y": 203
       },
       "hiddenSeries": false,
       "id": 163,
@@ -7280,7 +7440,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 213
+        "y": 211
       },
       "hiddenSeries": false,
       "id": 48,
@@ -7423,7 +7583,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 213
+        "y": 211
       },
       "hiddenSeries": false,
       "id": 92,
@@ -7627,7 +7787,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 221
+        "y": 219
       },
       "id": 77,
       "panels": [],
@@ -7652,7 +7812,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 222
+        "y": 220
       },
       "hiddenSeries": false,
       "id": 79,
@@ -7795,7 +7955,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 222
+        "y": 220
       },
       "hiddenSeries": false,
       "id": 156,
@@ -7932,7 +8092,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 230
+        "y": 228
       },
       "hiddenSeries": false,
       "id": 91,
@@ -8136,7 +8296,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 238
+        "y": 236
       },
       "id": 132,
       "panels": [],
@@ -8161,7 +8321,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 239
+        "y": 237
       },
       "hiddenSeries": false,
       "id": 134,
@@ -8365,7 +8525,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 247
+        "y": 245
       },
       "id": 65,
       "panels": [],
@@ -8396,7 +8556,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 248
+        "y": 246
       },
       "hiddenSeries": false,
       "id": 41,
@@ -8767,7 +8927,7 @@
         "h": 10,
         "w": 8,
         "x": 0,
-        "y": 257
+        "y": 255
       },
       "hiddenSeries": false,
       "id": 21,
@@ -8903,7 +9063,7 @@
         "h": 10,
         "w": 8,
         "x": 8,
-        "y": 257
+        "y": 255
       },
       "hiddenSeries": false,
       "id": 23,
@@ -9040,7 +9200,7 @@
         "h": 10,
         "w": 8,
         "x": 16,
-        "y": 257
+        "y": 255
       },
       "hiddenSeries": false,
       "id": 22,
@@ -9234,5 +9394,5 @@
   "timezone": "",
   "title": "SPPMON Long Term View (90 Days / Infinite)",
   "uid": "8pQ8jDSGk",
-  "version": 8
+  "version": 9
 }

--- a/Grafana/SPPMON for IBM Spectrum Protect Plus.json
+++ b/Grafana/SPPMON for IBM Spectrum Protect Plus.json
@@ -67,7 +67,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 5,
         "x": 0,
         "y": 1
@@ -159,7 +159,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 5,
         "x": 5,
         "y": 1
@@ -221,7 +221,7 @@
     {
       "cacheTimeout": null,
       "datasource": null,
-      "description": "95% Percentille / last 24h of each component memory usage",
+      "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -251,8 +251,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 4,
+        "h": 8,
+        "w": 5,
         "x": 10,
         "y": 1
       },
@@ -310,6 +310,61 @@
             ]
           ],
           "tags": []
+        },
+        {
+          "alias": "\"$tag_Mounted\" on $tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
         }
       ],
       "timeFrom": null,
@@ -359,9 +414,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 14,
+        "h": 8,
+        "w": 9,
+        "x": 15,
         "y": 1
       },
       "id": 136,
@@ -451,10 +506,10 @@
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "hiddenSeries": false,
       "id": 44,
@@ -632,10 +687,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 8,
-        "y": 8
+        "y": 9
       },
       "id": 139,
       "options": {
@@ -712,10 +767,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 12,
-        "y": 8
+        "y": 9
       },
       "id": 140,
       "options": {
@@ -792,10 +847,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 16,
-        "y": 8
+        "y": 9
       },
       "id": 138,
       "options": {
@@ -884,10 +939,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 20,
-        "y": 8
+        "y": 9
       },
       "id": 141,
       "options": {
@@ -945,6 +1000,151 @@
     },
     {
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 8,
+        "y": 12
+      },
+      "id": 98,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "targets": [
+        {
+          "alias": "$tag_ssh_type",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ssh_mpstat_cmd",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "%idle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "min"
+              },
+              {
+                "params": [
+                  "*-1 + 100"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Highest CPU load by Component",
+      "type": "stat"
+    },
+    {
+      "dashboardFilter": "",
+      "dashboardTags": [],
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "folderId": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 12
+      },
+      "id": 93,
+      "limit": "100",
+      "nameFilter": "",
+      "onlyAlertsOnDashboard": true,
+      "repeatDirection": "h",
+      "show": "current",
+      "sortOrder": 3,
+      "stateFilter": [
+        "execution_error",
+        "alerting",
+        "pending"
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SPP Alerts",
+      "type": "alertlist"
+    },
+    {
+      "datasource": null,
       "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
       "fieldConfig": {
         "defaults": {
@@ -970,9 +1170,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 7,
         "w": 4,
-        "x": 8,
+        "x": 16,
         "y": 12
       },
       "id": 142,
@@ -1174,40 +1374,6 @@
       "type": "gauge"
     },
     {
-      "dashboardFilter": "",
-      "dashboardTags": [],
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "folderId": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 12,
-        "y": 12
-      },
-      "id": 93,
-      "limit": "100",
-      "nameFilter": "",
-      "onlyAlertsOnDashboard": true,
-      "repeatDirection": "h",
-      "show": "current",
-      "sortOrder": 3,
-      "stateFilter": [
-        "execution_error",
-        "alerting",
-        "pending"
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "SPP Alerts",
-      "type": "alertlist"
-    },
-    {
       "cacheTimeout": null,
       "datasource": null,
       "description": "",
@@ -1242,7 +1408,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 16,
+        "x": 20,
         "y": 12
       },
       "id": 128,
@@ -1295,93 +1461,6 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Catalog Backup Duration",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "noValue": "N/A",
-          "nullValueMode": "connected",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 12
-      },
-      "id": 150,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.3.3",
-      "targets": [
-        {
-          "alias": "",
-          "groupBy": [
-            {
-              "params": [
-                "24h"
-              ],
-              "type": "time"
-            }
-          ],
-          "measurement": "jobs",
-          "orderByTime": "ASC",
-          "policy": "rp_days_90",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "jobLogsCount"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Job Logs Stored 24h",
       "type": "stat"
     },
     {
@@ -1599,117 +1678,6 @@
       "timeShift": null,
       "title": "SPP RAM Usage (by process)",
       "type": "bargauge"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "noValue": "N/A",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 65
-              },
-              {
-                "color": "red",
-                "value": 85
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 16,
-        "y": 16
-      },
-      "id": 98,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.3.3",
-      "targets": [
-        {
-          "alias": "$tag_ssh_type",
-          "groupBy": [
-            {
-              "params": [
-                "24h"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "ssh_type"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "ssh_mpstat_cmd",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT max(\"%idle\") *-1 + 100 FROM \"ssh_mpstat_cmd\" WHERE $timeFilter GROUP BY time(10m), \"COMMAND\"",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "%idle"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "min"
-              },
-              {
-                "params": [
-                  "*-1 + 100"
-                ],
-                "type": "math"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Highest CPU load by Component",
-      "type": "stat"
     },
     {
       "cacheTimeout": null,
@@ -1951,6 +1919,93 @@
           }
         }
       ],
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "N/A",
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 19
+      },
+      "id": 150,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "24h"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "jobs",
+          "orderByTime": "ASC",
+          "policy": "rp_days_90",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jobLogsCount"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Job Logs Stored 24h",
       "type": "stat"
     },
     {
@@ -3211,7 +3266,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 10,
-        "w": 12,
+        "w": 9,
         "x": 0,
         "y": 42
       },
@@ -3339,6 +3394,212 @@
       }
     },
     {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                80
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "1h",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "Storage Usage (Server & vSnap) alert",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 10,
+        "w": 7,
+        "x": 9,
+        "y": 42
+      },
+      "hiddenSeries": false,
+      "id": 174,
+      "legend": {
+        "avg": false,
+        "current": true,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$tag_ssh_type: $tag_hostName on \"$tag_Mounted\"",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "ssh_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "hostName"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "Mounted"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "df_ssh",
+          "orderByTime": "ASC",
+          "policy": "rp_days_14",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Use%"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "SERVER"
+            },
+            {
+              "condition": "OR",
+              "key": "ssh_type",
+              "operator": "=",
+              "value": "VSNAP"
+            }
+          ]
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 80
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Storage Usage (Server & vSnap)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:316",
+          "decimals": 0,
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:317",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -3354,8 +3615,8 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 10,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 42
       },
       "hiddenSeries": false,
@@ -5512,6 +5773,12 @@
           "groupBy": [
             {
               "params": [
+                "12h"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
                 "jobName"
               ],
               "type": "tag"
@@ -5521,6 +5788,12 @@
                 "resourceType"
               ],
               "type": "tag"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
             }
           ],
           "hide": false,
@@ -5536,6 +5809,10 @@
                   "total"
                 ],
                 "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
               }
             ]
           ],
@@ -12487,7 +12764,7 @@
       }
     }
   ],
-  "refresh": "5m",
+  "refresh": false,
   "schemaVersion": 26,
   "style": "dark",
   "tags": [],
@@ -12513,5 +12790,5 @@
   "timezone": "",
   "title": "SPPMON for IBM Spectrum Protect Plus",
   "uid": "PcYuUMSMk",
-  "version": 22
+  "version": 33
 }

--- a/python/influx/definitions.py
+++ b/python/influx/definitions.py
@@ -1163,12 +1163,12 @@ class Definitions:
             fields={
                 "Size":                     Datatype.INT,
                 "Used":                     Datatype.INT,
-                "Avail":                    Datatype.INT,
+                "Available":                Datatype.INT,
                 "Use%":                     Datatype.INT,
             },
             tags=[
                 "Filesystem",
-                "Mounted"
+                "Mounted",
                 "hostName",
                 "ssh_type"
             ],
@@ -1176,13 +1176,13 @@ class Definitions:
             continuous_queries=[
                 cls._CQ_DWSMPL([
                     "mean(\"Use%\") as \"Use%\"",
-                    "mean(Avail) as Avail",
+                    "mean(Available) as Available",
                     "mean(Used) as Used",
                     "mean(Size) as Size"
                     ], cls._RP_DAYS_90(), "6h"),
                 cls._CQ_DWSMPL([
                     "mean(\"Use%\") as \"Use%\"",
-                    "mean(Avail) as Avail",
+                    "mean(Available) as Available",
                     "mean(Used) as Used",
                     "mean(Size) as Size"
                     ], cls._RP_INF(), "1w")

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -43,6 +43,7 @@ Author:
  11/10/2020 version 0.10.3 Introduced --loadedSystem argument and moved --minimumLogs to depricated
  12/07/2020 version 0.10.4 Included SPP 10.1.6 addtional job information features and some bugfixes
  12/29/2020 version 0.10.5 Replaced ssh 'top' command by 'ps' command to bugfix truncating data
+ 01/22/2021 version 0.10.6 Removed `--processStats`, integrated in `--ssh` plus Server/vSnap `df` root recording
 """
 from __future__ import annotations
 import functools
@@ -71,7 +72,7 @@ from utils.methods_utils import MethodUtils
 from utils.spp_utils import SppUtils
 
 # Version:
-VERSION = "0.10.5  (2020/12/29)"
+VERSION = "0.10.6  (2021/01/22)"
 
 # ----------------------------------------------------------------------------
 # command line parameter parsing
@@ -83,7 +84,7 @@ parser.add_option("--verbose", dest="verbose", action="store_true", help="print 
 parser.add_option("--debug", dest="debug", action="store_true", help="save debug messages")
 
 parser.add_option("--constant", dest="constant", action="store_true",
-                  help="execute recommended constant functions: (ssh, processStats, cpu, sppCatalog)")
+                  help="execute recommended constant functions: (ssh, cpu, sppCatalog)")
 
 parser.add_option("--hourly", dest="hourly", action="store_true",
                   help="execute recommended hourly functions: (constant + jobs, vadps, storages)")
@@ -100,8 +101,6 @@ parser.add_option("--loadedSystem", dest="loadedSystem", action="store_true",
                   help="Special settings for loaded systems, reducing API-request loads")
 
 parser.add_option("--ssh", dest="ssh", action="store_true", help="execute monitoring commands via ssh")
-parser.add_option("--processStats", dest="processStats", action="store_true",
-                  help="monitor selected server processes via ssh")
 
 parser.add_option("--vms", dest="vms", action="store_true", help="store vm statistics (hyperV, vmWare)")
 parser.add_option("--vmStats", dest="vmStats", action="store_true", help="calculate vm statistic from catalog data")
@@ -115,9 +114,12 @@ parser.add_option("--cpu", dest="cpu", action="store_true", help="capture SPP se
 parser.add_option("--sppcatalog", dest="sppcatalog", action="store_true", help="capture Spp-Catalog Storage usage")
 
 ##########################
-#TODO Remove minimum Logs on next version.
+#TODO Remove minimum Logs and Processstats on next version.
 parser.add_option("--minimumLogs", dest="minimumLogs", action="store_true",
                   help="DEPRICATED, use '--loadedSystem' instead")
+parser.add_option("--processStats", dest="processStats", action="store_true",
+                  help="DEPRICATED, use '--ssh' instead")
+
 parser.add_option("--transfer_data", dest="transfer_data", action="store_true",
                   help="TEMPORARY FEATURE:transfer data into retention policies, BACKUP before doing so")
 parser.add_option("--old_database", dest="old_database",
@@ -526,7 +528,7 @@ class SppMon:
             ExceptionUtils.exception_info(error=error)
 
         # ############################### SSH #####################################
-        if(self.ssh or self.process_stats):
+        if(self.ssh):
             try:
 
                 auth_ssh = SppUtils.get_cfg_params(
@@ -568,7 +570,10 @@ class SppMon:
 
         if(OPTIONS.minimumLogs):
             ExceptionUtils.error_message(
-                "DEPRICATED: using depricated argument '--minumumLogs'. Switch to '--loadedSystem'.")
+                "DEPRICATED: using depricated argument '--minumumLogs'. Use to '--loadedSystem' instead.")
+        if(OPTIONS.processStats):
+            ExceptionUtils.error_message(
+                "DEPRICATED: using depricated argument '--minumumLogs'. Use to '--ssh' instead.")
 
         # incremental setup, higher executes all below
         all_args: bool = OPTIONS.all
@@ -597,7 +602,6 @@ class SppMon:
         # ######## Constant Methods ############
 
         self.ssh: bool = OPTIONS.ssh or constant
-        self.process_stats: bool = OPTIONS.processStats or constant
         self.cpu: bool = OPTIONS.cpu or constant
         self.spp_catalog: bool = OPTIONS.sppcatalog or constant
 
@@ -775,16 +779,6 @@ class SppMon:
                 ExceptionUtils.exception_info(
                     error=error,
                     extra_message="Top-level-error when excecuting ssh commands, skipping them all")
-
-        if(self.process_stats and self.ssh_methods):
-            # execute process stats for server
-            try:
-                self.ssh_methods.process_stats()
-                self.influx_client.flush_insert_buffer()
-            except ValueError as error:
-                ExceptionUtils.exception_info(
-                    error=error,
-                    extra_message="Top-level-error when excecuting ssh process statistic commands, skipping them all")
 
         # ################### HYPERVISOR METHODS #####################
         if(self.vms and self.hypervisor_methods):

--- a/python/sppmonMethods/ssh.py
+++ b/python/sppmonMethods/ssh.py
@@ -71,6 +71,9 @@ class SshMethods:
             # SEVER
             SshTypes.SERVER: [
                 # added later due function, check below
+
+                ## df -h /
+                ## df -h /opt/IBM/SPP
             ],
 
             # VSnap
@@ -85,6 +88,8 @@ class SshMethods:
                     parse_function=SshMethods._parse_system_stats_cmd,
                     table_name="vsnap_system_stats"
                 )
+                ##  zpool list
+                ##  df -h /
             ],
 
             # VADP

--- a/python/sppmonMethods/ssh.py
+++ b/python/sppmonMethods/ssh.py
@@ -72,6 +72,16 @@ class SshMethods:
             SshTypes.SERVER: [
                 # added later due function, check below
 
+                SshCommand(
+                    command='df -h / --block-size=G',
+                    parse_function=SshMethods._parse_df_cmd,
+                    table_name="df_ssh"
+                ),
+                SshCommand(
+                    command='df -h /opt/IBM/SPP --block-size=G',
+                    parse_function=SshMethods._parse_df_cmd,
+                    table_name="df_ssh"
+                ),
                 ## df -h /
                 ## df -h /opt/IBM/SPP
             ],
@@ -87,7 +97,12 @@ class SshMethods:
                     command='sudo vsnap --json system stats',
                     parse_function=SshMethods._parse_system_stats_cmd,
                     table_name="vsnap_system_stats"
-                )
+                ),
+                SshCommand(
+                    command='df -h / --block-size=G',
+                    parse_function=SshMethods._parse_df_cmd,
+                    table_name="df_ssh"
+                ),
                 ##  zpool list
                 ##  df -h /
             ],
@@ -105,7 +120,7 @@ class SshMethods:
             # OTHER
             SshTypes.OTHER: [
                 SshCommand(
-                    command="df -h -P",
+                    command="df -h --block-size=G",
                     parse_function=SshMethods._parse_df_cmd,
                     table_name="df_ssh"
                 )
@@ -375,8 +390,12 @@ class SshMethods:
             map(lambda row: dict(zip(header, row.split())), result_lines[1:])) # type: ignore
 
         for row in values:
+            if("1G-blocks" in row):
+                row["Size"] = row.pop("1G-blocks")
             row["Size"] = SppUtils.parse_unit(row['Size'])
-            row["Avail"] = SppUtils.parse_unit(row['Avail'])
+            if("Avail" in row):
+                row["Available"] = row.pop("Avail")
+            row["Available"] = SppUtils.parse_unit(row['Available'])
             row["Used"] = SppUtils.parse_unit(row['Used'])
             row["Use%"] = row["Use%"][:-1]
 

--- a/python/sppmonMethods/ssh.py
+++ b/python/sppmonMethods/ssh.py
@@ -167,24 +167,10 @@ class SshMethods:
                 list_with_dicts=insert_list
             )
 
-    def process_stats(self) -> None:
-        """Executes all server-process stats related functionality."""
-        try:
-            LOGGER.info(f"> executing process_stats ssh commands")
-            self.__exec_save_commands(
-                ssh_type=SshTypes.SERVER,
-                command_list=self.__client_commands[SshTypes.SERVER] + self.__all_command_list
-            )
-        except ValueError as error:
-            ExceptionUtils.exception_info(
-                error=error, extra_message="Top-level-error when process_stats ssh commands, skipping them all")
-
     def ssh(self) -> None:
         """Executes all ssh related functionality for each type of client each."""
         LOGGER.info(f"> executing ssh commands for each sshclient-type individually.")
         for ssh_type in SshTypes:
-            if(ssh_type is SshTypes.SERVER):
-                continue # skip due the method process_stats, already collected there
             try:
                 LOGGER.info(f">> executing ssh commands, which are labled to be executed for {ssh_type.value} ssh clients")
                 self.__exec_save_commands(


### PR DESCRIPTION
- Includes `df` command to server and vsnap only
  - Others may be included on request
- Monitoring `/` root and on server also `/opt/IBM/SPP`. 
- Breaking old table `df_ssh`: renamed field `Avail` to `Available` for more consistency.
  - Effects should be minor, this table is only used for the rarely used `other`-ssh-type.
 - renamed SPPMon argument `--processStats` since it is misleading, not only containing process commands, but all commands against the server
   - `--processStats` now labled as `DEPRICATED`, to be removed in V1.0
   - Integrated this command into the `--ssh` command, extending it functionality to executing any ssh-command
- Updated Grafana panels:
  - Includes now this new information in Overview (all) + below (14/90-days)
  - Reoganized Overview of 14-days and multiple server
  - Fixed "Total count by Resource Type" in 14-Days.
   
  