### PR TITLE
Hotfixes statistic joblogs and --test check for ssh_commands

### DIFF
--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -47,6 +47,7 @@ Author:
  01/22/2021 version 0.10.7 Replaced `transfer_data` by `copy_database` with improvements
  01/28/2021 version 0.11   Copy_database now also creates the database with RP's if missing.
  01/29/2021 version 0.12   Implemented --test function, also disabeling regular setup on certain args
+ 02/09/2021 version 0.12.1 Hotfix job statistic and --test now also checks for all commands individually
 """
 from __future__ import annotations
 import functools
@@ -74,7 +75,7 @@ from utils.methods_utils import MethodUtils
 from utils.spp_utils import SppUtils
 
 # Version:
-VERSION = "0.12  (2021/01/29)"
+VERSION = "0.12.1  (2021/02/09)"
 
 # ----------------------------------------------------------------------------
 # command line parameter parsing

--- a/python/sppmonMethods/jobs.py
+++ b/python/sppmonMethods/jobs.py
@@ -233,7 +233,8 @@ class JobMethods:
         LOGGER.info(f">>> computing additional job statistics for jobId: {job_id}")
 
         insert_list: List[Dict[str, Any]] = []
-        for job in filter(lambda x: x.get("statistics", None), list_with_jobs):
+        # check for none instead of bool-check: Remove empty statistic lists [].
+        for job in filter(lambda x: x.get("statistics", None) is not None, list_with_jobs):
             job_statistics_list = job.pop('statistics')
 
             for job_stats in job_statistics_list:

--- a/python/sppmonMethods/ssh.py
+++ b/python/sppmonMethods/ssh.py
@@ -7,7 +7,7 @@ Classes:
 import json
 import logging
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 from influx.influx_client import InfluxClient
 from sppConnection.ssh_client import SshClient, SshCommand, SshTypes
@@ -24,6 +24,10 @@ class SshMethods:
     Split into parse methods and execute methods. All parse methods are reusable for each type of server.
     Those parse functions need a special signature to be automatically executed in the `SshCommand`s.
 
+    Attributes:
+        all_command_list
+        client_commands
+
     Methods:
         process_stats
         ssh
@@ -31,7 +35,17 @@ class SshMethods:
 
     """
 
-    def __init__(self, influx_client: Optional[InfluxClient], config_file: Dict[str, Any], verbose: bool = False):
+    @property
+    def all_command_list(self) -> List[SshCommand]:
+        """Commands to be executed on every ssh-client"""
+        return self.__all_command_list
+
+    @property
+    def client_commands(self) -> Dict[SshTypes, List[SshCommand]]:
+        """Mapping of ssh commands to be executed on the mapped type"""
+        return self.__client_commands
+
+    def __init__(self, influx_client: InfluxClient, config_file: Dict[str, Any], verbose: bool = False):
         if(not config_file):
             raise ValueError("Require config file to setup ssh clients")
         if(not influx_client):


### PR DESCRIPTION
- Hotfixed --jobs to not throw an error when having a empty `statistic` list.
- `--test` now also checks if ally ssh-commands itself are available.