### PR TITLE
Minor Fixes and Tracking code for NaN Bug

### DIFF
--- a/python/influx/database_tables.py
+++ b/python/influx/database_tables.py
@@ -262,7 +262,7 @@ class Table:
         return f"Table: {self.name}"
 
     def split_by_table_def(self, mydict: Dict[str, Any]) -> Tuple[
-            Dict[str, Any], Dict[str, Any], Union[str, int, None]]:
+            Dict[str, Any], Dict[str, Any], Union[str, int]]:
         """Split the given dict into a pre-defined set of tags, fields and a timestamp.
 
         None-Values and empty strings are ignored.
@@ -339,6 +339,10 @@ class Table:
                 ExceptionUtils.error_message(f"Not all columns for table {self.name} are declared: {key}")
                 # before key+"MISSING" : Removed to avoid death-circle on repeated queries.
                 fields[key] = value
+        if(time_stamp is None):
+            ExceptionUtils.error_message(f"No timestamp value gathered for table {self.name}, using current time: {mydict}")
+            time_stamp = SppUtils.get_actual_time_sec()
+
         return (tags, fields, time_stamp)
 
 class Database:

--- a/python/influx/influx_client.py
+++ b/python/influx/influx_client.py
@@ -266,7 +266,7 @@ class InfluxClient:
             ExceptionUtils.exception_info(error=error) # type: ignore
             raise ValueError("Continuous Query check failed")
 
-    def copy_database(self, new_database_name: str = None) -> None:
+    def copy_database(self, new_database_name: str) -> None:
         if(not new_database_name):
             raise ValueError("copy_database requires a new database name to copy to.")
 

--- a/python/influx/influx_queries.py
+++ b/python/influx/influx_queries.py
@@ -57,7 +57,7 @@ class InsertQuery:
         return self.__table
 
     def __init__(self, table: Structures.Table, fields: Dict[str, Any], tags: Dict[str, Any] = None,
-                 time_stamp: Union[int, str] = None):
+                 time_stamp: Union[int, str, None] = None):
         if(not table):
             raise ValueError("need table to create query")
         if(not fields):
@@ -88,7 +88,7 @@ class InsertQuery:
             if(not list(filter(lambda field_tup: field_tup[1] is not None, fields.items()))):
                 raise ValueError("fields after formatting empty, need at least one value!")
 
-        self.__fields: Dict[str, Union[int, float, str, bool]] = fields
+        self.__fields: Dict[str, Union[float, str, bool]] = fields
         self.__tags: Dict[str, str] = self.format_tags(tags)
 
     def __str__(self) -> str:
@@ -121,7 +121,7 @@ class InsertQuery:
 
         return f'{self.table.name}{tag_str} {fields_str} {time_stamp_str}'
 
-    def format_fields(self, fields: Dict[str, Any]) -> Dict[str, Union[int, float, str]]:
+    def format_fields(self, fields: Dict[str, Any]) -> Dict[str, Union[bool, float, str]]:
         """Formats fields accordingly to the requirements of the influxdb.
 
         Cast and transforms all values to the required datatype, declared in the given table.
@@ -134,16 +134,13 @@ class InsertQuery:
         Returns:
             Dict[str, Union[int, float, str]] -- Dict with field name as key and data as value
         """
-        ret_dict: Dict[str, Union[int, float, str]] = {}
+        ret_dict: Dict[str, Union[float, str, bool]] = {}
         for(key, value) in fields.items():
-            if(value is None or (isinstance(value, str) and not value)):
+            if(value is None or value == ""):
                 continue
 
-            # Get Colum Datatype
-            datatype = self.table.fields.get(key, None)
-            # If nothing is defined select it automatic
-            if(datatype is None):
-                datatype = Structures.Datatype.get_auto_datatype(value)
+            # Get Colum Datatype; if nothing is defined select it automatic
+            datatype = self.table.fields.get(key, Structures.Datatype.get_auto_datatype(value))
 
             # Escape not allowed chars in Key
             key = InfluxUtils.escape_chars(value=key, replace_list=self.__bad_name_characters)

--- a/python/sppConnection/api_queries.py
+++ b/python/sppConnection/api_queries.py
@@ -257,6 +257,10 @@ class ApiQueries:
         LOGGER.debug("retrieving actual SPP server CPU and RAM usage")
         endpoint = "/ngp/metrics"
         metrics = self.__rest_client.get_objects(endpoint=endpoint, add_time_stamp=True)
+        # TODO This is a error-catching code. REMOVE ONCE BUG is found!
+        result_dict = metrics[0]
+        if(result_dict["cpuUtil"] == "NaN" or result_dict["memory.util"] =="NaN"):
+            ExceptionUtils.error_message(f"CRITICAL: REPORT TO DEVELOPER! cpuUtil or memoryUtil is NaN. API-response: {result_dict}")
         return metrics
 
     def get_file_system(self) -> List[Dict[str, Any]]:

--- a/python/sppConnection/api_queries.py
+++ b/python/sppConnection/api_queries.py
@@ -257,10 +257,6 @@ class ApiQueries:
         LOGGER.debug("retrieving actual SPP server CPU and RAM usage")
         endpoint = "/ngp/metrics"
         metrics = self.__rest_client.get_objects(endpoint=endpoint, add_time_stamp=True)
-        # TODO This is a error-catching code. REMOVE ONCE BUG is found!
-        result_dict = metrics[0]
-        if(result_dict["cpuUtil"] == "NaN" or result_dict["memory.util"] =="NaN"):
-            ExceptionUtils.error_message(f"CRITICAL: REPORT TO DEVELOPER! cpuUtil or memoryUtil is NaN. API-response: {result_dict}")
         return metrics
 
     def get_file_system(self) -> List[Dict[str, Any]]:

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -2,8 +2,8 @@
 (C) IBM Corporation 2020
 
 Description:
- Monitoring and long-term reporting for IBM Spectrum Protect Plus. 
- Provides a data bridge from SPP to InfluxDB and provides visualization dashboards via Grafana. 
+ Monitoring and long-term reporting for IBM Spectrum Protect Plus.
+ Provides a data bridge from SPP to InfluxDB and provides visualization dashboards via Grafana.
 
  This program provides functions to query IBM Spectrum Protect Plus Servers,
  VSNAP, VADP and other servers via REST API and ssh. This data is stored into a InfluxDB database.
@@ -637,8 +637,9 @@ class SppMon:
             if(error_count > 0):
                 ExceptionUtils.error_message(f"total of {error_count} exception/s occured")
             insert_dict['errorCount'] = error_count
-            # save list as str
-            insert_dict['errorMessages'] = str(ExceptionUtils.stored_errors)
+            # save list as str if not empty
+            if(ExceptionUtils.stored_errors):
+                insert_dict['errorMessages'] = str(ExceptionUtils.stored_errors)
 
             # get end timestamp
             (time_key, time_val) = SppUtils.get_capture_timestamp_sec()

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -53,6 +53,7 @@ Author:
  02/09/2021 version 0.12.1 Hotfix job statistic and --test now also checks for all commands individually
  02/07/2021 version 0.13   Implemented additional Office365 Joblog parsing
  02/10/2021 version 0.13.1 Fixes to partial send(influx), including influxdb version into stats
+ 03/29/2021 version 0.13.2 Fixes to typing, reducing error messages and tracking code for NaN bug
 
 """
 from __future__ import annotations
@@ -81,7 +82,7 @@ from utils.methods_utils import MethodUtils
 from utils.spp_utils import SppUtils
 
 # Version:
-VERSION = "0.13.1  (2021/02/10)"
+VERSION = "0.13.2  (2021/03/29)"
 
 # ----------------------------------------------------------------------------
 # command line parameter parsing

--- a/python/sppmonMethods/ssh.py
+++ b/python/sppmonMethods/ssh.py
@@ -342,6 +342,8 @@ class SshMethods:
             # set default needed fields
             pool_dict['hostName'] = ssh_command.host_name
             pool_dict['ssh_type'] = ssh_type.name
+            (time_key, time_value) = SppUtils.get_capture_timestamp_sec()
+            pool_dict[time_key] = time_value
 
             pool_result_list.append(pool_dict)
 

--- a/python/utils/influx_utils.py
+++ b/python/utils/influx_utils.py
@@ -186,4 +186,8 @@ class InfluxUtils:
             ExceptionUtils.error_message(f"missing field in {mydict}")
             fields["MISSING_FIELD"] = 42
 
+        if(time_stamp is None):
+            ExceptionUtils.error_message(f"No timestamp value gathered when using default split, using current time: {mydict}")
+            time_stamp = SppUtils.get_actual_time_sec()
+
         return (tags, fields, time_stamp)


### PR DESCRIPTION
- included code to track NaN cpuUtil Bug (see issue #52)
- Only save error messages if they are not empty (`!= []`)
- Prevent future implementation bug if a entry does not have a timestamp to report this issue
- fixes some typings within the code