### PR TITLE
Vadp fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,33 @@ straightforward as possible.
 
 ### Fixed
 
+## [1.0.2] - 2021-08-31
+
+### Changed
+
+* Marked the default group time when using the template CQ more clearly as `[*]`
+* Grafana Dashboards:
+  * 14-Day dashboard:
+    * Changed VADP Proxy state table to support the VADPName grouping and status
+      * Used Grafana organizing mechanics to leave query intact, hiding old data with status=null and vadpName="".
+    * Changed VADP Proxy state per site to only use new data since 14-day is not too long
+      * Changed to use field count and group over status instead of two separate queries
+  * 90-Day dashboard:
+    * Changed %-Enabled VADP dashboard to total count dashboard
+    * Added for both VADP Proxy state and total count dashboard a new query, grouping over status and grouping on `count`. Old queries left intact for backward compatibility.
+    * Hides series with null/none, adding average to legend.
+
+* InfluxDB-Table `VADPs`:
+  * Moved fields `state` and `vadpName` to tags
+    * Renamed `state` to `status` to avoid issues due to double-named tags/fields
+  * Changed CQ to group only over 'old' Tags
+  * Changed aggregation from a split over enabled/disable to grouping over the state itself.
+    This removes now-duplicate CQ definitions and all `WHERE`-grouping clauses.
+
+### Fixed
+
+* VADPs are no longer dropped due to being marked as duplicates by the InfluxDB.
+
 ## [1.0.1] - 2021-08-27
 
 ### Fixed
@@ -46,11 +73,11 @@ straightforward as possible.
 
 #### Added
 
-* Install Script for automatically installing SPPMon, Python, InfluxDB, and Grafana on a blank CentOs system.
-  * Features a `--alwaysConfirm` argument for less confirmations
+* Install script for automatically installing SPPMon, Python, InfluxDB, and Grafana on a blank CentOs system.
+  * Features a `--alwaysConfirm` argument for fewer confirmations
 * Two stand-alone python scripts for automatically creating Config files and adding them to crontab
   > These scripts are used within the install script
-* Created script `scripts/generifyDashboard.py`, which is now on developer side. This makes sure a dashboard exported for external use is truly generic.
+* Created script `scripts/generifyDashboard.py`, which is now on the developer side. This makes sure a dashboard exported for external use is truly generic.
   > See Grafana changes for reasoning
 
 ### Python / Execution
@@ -59,38 +86,38 @@ straightforward as possible.
 
 * `--test`:  Fixes Abort without summary on SSH-Errors
 * Fixes empty error message without explanation if sites are an empty array
-  * Also adds debug output for easier remote tracing
-* Corrupted config-file path no longer breaks SPPMon but prints a error message
-* Partly fixes #40, but some ID's still remain missing due other issues. Descriped within issue itself.
-* JobLogs: The type-filter is no longer ignored on regular/loaded execution - requesting way less logs.
-* Fixed an error when importing individual job log statistics and `ressourceType` was missing
+  * Adds debug output for easier remote tracing
+* Corrupted config-file path no longer breaks SPPMon but prints an error message
+* Partly fixes #40, but some IDs still remain missing due to other issues. The fix is described within the issue.
+* JobLogs: The type-filter is no longer ignored on regular/loaded execution - requesting way fewer logs.
+* Fixed an error when importing individual job log statistics, and `ressourceType` was missing
 
 #### Changes
 
 * Replaces OptionParser with Argumentparser
-* Improves `--test` argument: Outsources code, improves display and messages.
+* Improves `--test` argument: Outsources code, improve display and messages.
   * Enhanced Description and help message
   * Catches typos and missing arguments within the parser
 * Removed disallowed terms from SPPMon code, using `allow_list` instead
 * Reworks REST-API POST-Requests to be merged with GET-Requests
   * This includes the repeated tries if a request fails
   * Deprecates `url_set_param`, using functionality of `requests`-package instead
-  * Using Python-Structs for url-params instead of cryptical encoded params
-* Reworks REST-API requests even more to use parameters more efficient and consistent, making the code hopefully more readable.
+  * Using Python-Structs for URL-params instead of cryptical encoded params
+* Reworks REST-API requests to use parameters more efficiently and consistently, making the code hopefully more readable.
   * Changes get_url_params to gain all parameters from URL-Encoding
   * Introduces set_url_params to set all params into URL encoding
-  * Reads params of next page and allows injecting whole dictionary of params
-* Changes vms per SLA-request to not query all vms anymore, ~~but using pageSize to 1 and reading the `total` aggregated field and not repeat for other pages~~.
+  * Reads params of next page and allows injecting the whole dictionary of params
+* Changes VMs per SLA-request to not query all VMs anymore, ~~but using pageSize to 1 and reading the `total` aggregated field and not repeat for other pages~~.
   * Changed to query so-far unknown endpoint, using count and group aggregate to query all data with a single API-request
-  > This brings the sla-request in line with the other api-requests.
-* Reworked/Commented the job-log request and prepared a filter via individual joblog-ID's
-* Labeled python argument ` -create_dashboard` and associated args as depricated, to be removed in v1.1 (See Grafana-Changes)
+  > This brings the SLA request in line with the other API requests.
+* Reworked/Commented the job-log request and prepared a filter via individual JobLog-ID's
+* Labeled python argument ` -create_dashboard` and associated args as deprecated, to be removed in v1.1 (See Grafana-Changes)
 
 ### Influx
 
 #### Changes
 
-* Checks user (GrafanaReader) for permissions (READ) on current Database, warns if user not exists and grands permissions if missing (Feature of V1.0)
+* Checks user (GrafanaReader) for permissions (READ) on current Database, warns if user not exists, and grants permissions if missing (Feature of V1.0)
 * Reworks Influx-write Queries to repeat once if failed with fallback options
   * This includes enhanced error messages
   * Influx-Statistic send is reworked to be per table
@@ -98,15 +125,15 @@ straightforward as possible.
 
 #### Fixes
 
-* Optimized Continious-Queries setup
-  * No longer all CQ are re-build on start of **all** sppmon exections, works now as intended
-  * Changed definition to match influxDB return values (7d -> 1 w)
-  * Changed quotations to match influxDB return values
+* Optimized Continuous-Queries setup
+  * No longer all CQ is re-build on the start of **all** SPPMon executions, works now as intended
+  * Changed definition to match InfluxDB return values (7d -> 1 w)
+  * Changed quotations to match InfluxDB return values
 
 #### Breaking Changes
 
 * Typo fix in stddev, breaking old data.
-  * These numbers are used nowhere, therefore this will likley not break anything
+  * These numbers are used nowhere, this will likely not break anything
   * Old Data is still available by the old name `sttdev`
 
 ### Grafana-Dashboards
@@ -116,27 +143,27 @@ straightforward as possible.
 * Added Hyper-V Job Duration Panel similar to VMWare-Panel into 14 and 90/INF Dashboard
 * Added versioning tags to each dashboard. Starting with v1.0
 * Added unique data source tags to the 14-day dashboard
-  * They have no use yet, but might be used for directly referencing onto a certain dashboard from 90-days/mult dashboard
-* Added unique tags for identifying 14-day, 90-day and mult dashboards
-* Created links from each dashboards to the others, grouped by type
+  * They have no use yet but might be used for directly referencing onto a certain dashboard from 90-days/multiple dashboards
+* Added unique tags for identifying 14-day, 90-day, and multiple dashboards
+* Created links from each dashboard to the others, grouped by type
   * The 14-days dashboards are created as dropdown
 
 #### Changes
 
 * Changed dashboard to be exported for `external use`:
-  * You may change the datasource on importing
-  * Both UID and Dashboard name will be variable generated based on datasource chosen
-  * Labeled python argument ` -create_dashboard` and associated args as depricated, to be removed in v1.1
-    > Note: Listed here only for completeness, see python changes
-  * Created pyhton stand-alone script for generifying dashboard
+  * You may change the data source on importing
+  * Both UID and Dashboard names will be variable generated based on the data source chosen
+  * Labeled Python argument ` -create_dashboard` and associated args as deprecated, to be removed in v1.1
+    > Note: Listed here only for completeness, see Python changes
+  * Created a Python stand-alone script for generifying dashboard
     > Note: Listed here only for completeness, see script changes
 
 ## [0.5.4-beta] - 2021-08-11
 
 ### Fixes
 
-* Bugfixes flat CPU-statistics due `ps` unexpected behavior.
-  * `ps` no longer tracks CPU-Data, Track of RAM and some other system informations remains.
+* Bugfixes flat CPU statistics due to `ps` unexpected behavior.
+  * `ps` no longer tracks CPU-Data, Track of RAM, and some other system information remains.
   * Re-introduced `top`-ssh command, but only collecting CPU-Statistics (see top-memory-truncation issue #14 & #32)
   > **The process-stats panel is accurate again after applying this fix.**
 
@@ -146,7 +173,7 @@ straightforward as possible.
 
 * Changed top-level exception catching: Catches any exceptions instead of only our self-defined ValueErrors
   -> Prevents a complete abort of SPPMon if something unexpected happens.
-  -> **This will reduce the need of urgent hotfixes like this one.**
+  -> **This will reduce the need for urgent hotfixes like this one.**
 * Changes empty result severity of REST-Requests from error to info
 * Changed typings from critical components to support better linting
 

--- a/Grafana/SPPMON Long Term View (90 Days _ Infinite).json
+++ b/Grafana/SPPMON Long Term View (90 Days _ Infinite).json
@@ -9,6 +9,12 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
@@ -18,7 +24,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 55,
-  "iteration": 1629367378778,
+  "iteration": 1630413895162,
   "links": [
     {
       "asDropdown": false,
@@ -73,10 +79,6 @@
       "datasource": "$SPP_Server",
       "decimals": 1,
       "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -107,7 +109,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -214,10 +216,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "description": "max 90% Percentille  of each component memory usage",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -245,7 +243,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -333,10 +331,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "description": "Duration selected jobs",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -364,7 +358,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -466,10 +460,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -496,7 +486,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -604,10 +594,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -634,7 +620,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -753,10 +739,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -786,7 +768,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -869,10 +851,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -899,7 +877,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1009,10 +987,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "description": "Sum of replicated bytes \nSum of transferred bytes\n",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1042,7 +1016,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1189,10 +1163,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1222,7 +1192,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1342,10 +1312,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -1373,7 +1339,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 0.5,
       "points": true,
       "renderer": "flot",
@@ -1630,7 +1596,7 @@
           }
         ]
       },
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "",
@@ -1736,10 +1702,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -1767,7 +1729,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 0.5,
       "points": true,
       "renderer": "flot",
@@ -2026,10 +1988,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "decimals": 1,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -2059,7 +2017,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2171,10 +2129,6 @@
       "datasource": "$SPP_Server",
       "decimals": 1,
       "description": "Selected Processes monitored by top command\n\"java\", \"mongo\", \"beam.smp\"",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -2207,7 +2161,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2320,10 +2274,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "decimals": 1,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -2352,7 +2302,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2459,10 +2409,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -2489,7 +2435,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -2609,10 +2555,6 @@
       "datasource": "$SPP_Server",
       "decimals": 1,
       "description": "Mean-Sum of process-group displayed",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -2643,7 +2585,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -2758,10 +2700,6 @@
       "datasource": "$SPP_Server",
       "decimals": 1,
       "description": "Selected Processes monitored by top command\n\"java\", \"mongo\", \"beam.smp\"",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -2794,7 +2732,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -2901,10 +2839,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2932,7 +2866,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3019,10 +2953,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3050,7 +2980,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3176,10 +3106,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3206,7 +3132,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3337,10 +3263,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -3370,7 +3292,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3462,10 +3384,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3492,7 +3410,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3582,10 +3500,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3612,7 +3526,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3702,10 +3616,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3732,7 +3642,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3829,10 +3739,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3859,7 +3765,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3968,10 +3874,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3998,7 +3900,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4107,10 +4009,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4137,7 +4035,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4227,10 +4125,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4257,7 +4151,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4366,10 +4260,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4396,7 +4286,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4512,10 +4402,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "decimals": 0,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -4544,7 +4430,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4644,10 +4530,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -4676,7 +4558,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -4816,10 +4698,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -4848,7 +4726,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4944,10 +4822,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "decimals": 0,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -4976,7 +4850,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -5094,10 +4968,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "decimals": 0,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -5126,7 +4996,7 @@
         "alertThreshold": true
       },
       "percentage": true,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -5270,10 +5140,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 0,
       "fillGradient": 1,
       "gridPos": {
@@ -5300,7 +5166,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -5422,10 +5288,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 2,
       "gridPos": {
@@ -5452,7 +5314,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -5551,10 +5413,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -5582,7 +5440,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -5667,10 +5525,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 0,
       "fillGradient": 1,
       "gridPos": {
@@ -5697,7 +5551,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -5825,10 +5679,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -5857,7 +5707,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -6088,10 +5938,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -6118,7 +5964,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -6232,10 +6078,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -6262,7 +6104,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -6396,10 +6238,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -6426,7 +6264,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -6540,10 +6378,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -6570,7 +6404,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -6684,10 +6518,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -6714,7 +6544,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -6828,10 +6658,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -6858,7 +6684,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -6970,10 +6796,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -7001,7 +6823,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -7105,10 +6927,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "description": "Selects mean of each unique storage, sums up to total per site",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -7136,7 +6954,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -7226,10 +7044,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -7257,7 +7071,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -7361,10 +7175,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "description": "Selects mean of each unique storage, sums up to total per site",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -7392,7 +7202,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -7500,10 +7310,6 @@
       "dashes": false,
       "datasource": "$SPP_Server",
       "decimals": 1,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -7533,7 +7339,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -7641,10 +7447,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -7671,7 +7473,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -7868,10 +7670,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -7883,13 +7681,15 @@
       "hiddenSeries": false,
       "id": 79,
       "legend": {
-        "avg": false,
+        "avg": true,
         "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
         "max": false,
         "min": false,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -7898,7 +7698,221 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Enabled",
+          "groupBy": [
+            {
+              "params": [
+                "$interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "vadps",
+          "orderByTime": "ASC",
+          "policy": "$rp",
+          "query": "SELECT count(\"state\") FROM \"rp_half_year\".\"vadps\" WHERE (\"state\" =~ /ENABLED/) AND $timeFilter GROUP BY time($interval), \"siteName\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "enabled_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Disabled",
+          "groupBy": [
+            {
+              "params": [
+                "$interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "vadps",
+          "orderByTime": "ASC",
+          "policy": "$rp",
+          "query": "SELECT count(\"state\") FROM \"rp_half_year\".\"vadps\" WHERE (\"state\" =~ /ENABLED/) AND $timeFilter GROUP BY time($interval), \"siteName\"",
+          "rawQuery": false,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "disabled_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "$tag_status",
+          "groupBy": [
+            {
+              "params": [
+                "$interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "status"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "vadps",
+          "orderByTime": "ASC",
+          "policy": "$rp",
+          "query": "SELECT count(\"state\") FROM \"rp_half_year\".\"vadps\" WHERE (\"state\" =~ /ENABLED/) AND $timeFilter GROUP BY time($interval), \"siteName\"",
+          "rawQuery": false,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VADP Proxy State Total Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transformations": [],
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:11956",
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:11957",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$SPP_Server",
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 220
+      },
+      "hiddenSeries": false,
+      "id": 156,
+      "legend": {
+        "avg": true,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -7921,12 +7935,6 @@
                 "siteName"
               ],
               "type": "tag"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
             }
           ],
           "measurement": "vadps",
@@ -7947,109 +7955,53 @@
               {
                 "params": [],
                 "type": "sum"
-              },
-              {
-                "params": [
-                  " / (sum(enabled_count)+sum(disabled_count))"
-                ],
-                "type": "math"
               }
             ]
           ],
           "tags": []
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "VADP Proxy State",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:11956",
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": "1",
-          "min": "0",
-          "show": true
         },
         {
-          "$$hashKey": "object:11957",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 1,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 220
-      },
-      "hiddenSeries": false,
-      "id": 156,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
+          "alias": "$tag_siteName Disabled",
+          "groupBy": [
+            {
+              "params": [
+                "$interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "siteName"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "vadps",
+          "orderByTime": "ASC",
+          "policy": "$rp",
+          "query": "SELECT count(\"state\") FROM \"rp_half_year\".\"vadps\" WHERE (\"state\" =~ /ENABLED/) AND $timeFilter GROUP BY time($interval), \"siteName\"",
+          "rawQuery": false,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "disabled_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
         {
-          "alias": "$tag_siteName Enabled Count",
+          "alias": "$tag_siteName $tag_status",
           "groupBy": [
             {
               "params": [
@@ -8065,23 +8017,24 @@
             },
             {
               "params": [
-                "none"
+                "status"
               ],
-              "type": "fill"
+              "type": "tag"
             }
           ],
+          "hide": false,
           "measurement": "vadps",
           "orderByTime": "ASC",
           "policy": "$rp",
           "query": "SELECT count(\"state\") FROM \"rp_half_year\".\"vadps\" WHERE (\"state\" =~ /ENABLED/) AND $timeFilter GROUP BY time($interval), \"siteName\"",
           "rawQuery": false,
-          "refId": "A",
+          "refId": "B",
           "resultFormat": "time_series",
           "select": [
             [
               {
                 "params": [
-                  "enabled_count"
+                  "count"
                 ],
                 "type": "field"
               },
@@ -8116,6 +8069,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:11956",
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -8130,7 +8084,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
@@ -8144,10 +8098,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -8174,7 +8124,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -8371,10 +8321,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -8401,7 +8347,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -8604,10 +8550,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -8634,7 +8576,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -8973,10 +8915,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -9003,7 +8941,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -9107,10 +9045,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -9137,7 +9071,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -9242,10 +9176,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$SPP_Server",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -9272,7 +9202,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -9372,11 +9302,11 @@
     }
   ],
   "refresh": "1h",
-  "schemaVersion": 27,
+  "schemaVersion": 30,
   "style": "dark",
   "tags": [
     "90_days_inf",
-    "v1.0"
+    "v1.0.2"
   ],
   "templating": {
     "list": [
@@ -9451,5 +9381,5 @@
   "timezone": "",
   "title": "SPPMON Long Term View (90 Days / Infinite)",
   "uid": "sppmon_long_term_view",
-  "version": 2
+  "version": 4
 }

--- a/Grafana/SPPMON for IBM Spectrum Protect Plus.json
+++ b/Grafana/SPPMON for IBM Spectrum Protect Plus.json
@@ -9935,7 +9935,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "$tag_siteName $tag_state",
+          "alias": "$tag_siteName $tag_status",
           "groupBy": [
             {
               "params": [

--- a/Grafana/SPPMON for IBM Spectrum Protect Plus.json
+++ b/Grafana/SPPMON for IBM Spectrum Protect Plus.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_SCALEVM10V2_EXTERNAL",
-      "label": "scaleVM10v2 external",
+      "name": "DS_DATASOURCE",
+      "label": "Datasource",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -143,7 +143,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -156,7 +156,7 @@
       "type": "row"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "95% Percentille over last 24h ",
       "fieldConfig": {
         "defaults": {
@@ -248,7 +248,7 @@
       "type": "gauge"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "95% Percentille over last 24h ",
       "fieldConfig": {
         "defaults": {
@@ -341,7 +341,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
       "fieldConfig": {
         "defaults": {
@@ -495,7 +495,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "Duration of the last execution of selected jobs",
       "fieldConfig": {
         "defaults": {
@@ -614,7 +614,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 1,
       "description": "",
       "fill": 1,
@@ -781,7 +781,7 @@
       }
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -861,7 +861,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -941,7 +941,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -1033,7 +1033,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -1113,7 +1113,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -1224,7 +1224,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 7,
         "w": 4,
@@ -1258,7 +1258,7 @@
       "type": "alertlist"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
       "fieldConfig": {
         "defaults": {
@@ -1489,7 +1489,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1577,7 +1577,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "90% percentille of last 24h per Commandgroup",
       "fieldConfig": {
         "defaults": {
@@ -1685,7 +1685,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "90% percentille of last 24h",
       "fieldConfig": {
         "defaults": {
@@ -1794,7 +1794,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "Sum of replicated bytes (VM) within the last 24h\nSum of transferred bytes (VM) within the last 24h\nSum of transferred bytes (Office365) within the last 24h\n",
       "fieldConfig": {
         "defaults": {
@@ -1946,7 +1946,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -2058,7 +2058,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2144,7 +2144,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2221,7 +2221,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 1,
@@ -2440,7 +2440,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 1,
       "description": "Selected Processes monitored by top command\n\"java\", \"mongo\", \"beam.smp\".\nQuerie calcualted due an inner querie to filter out the PID. Simple \"mean\" would result in a falsly low result",
       "fill": 1,
@@ -2631,7 +2631,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 1,
@@ -2828,7 +2828,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -3033,7 +3033,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 1,
       "description": "Mean-Sum of process-group displayed",
       "fill": 1,
@@ -3187,7 +3187,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 1,
       "description": "Selected Processes monitored by top command\n\"java\", \"mongo\", \"beam.smp\"",
       "fill": 1,
@@ -3364,7 +3364,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3538,7 +3538,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 0,
       "description": "",
       "fill": 1,
@@ -3704,7 +3704,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3876,7 +3876,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3893,7 +3893,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -4065,7 +4065,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4255,7 +4255,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4432,7 +4432,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4609,7 +4609,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4787,7 +4787,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4947,7 +4947,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -5133,7 +5133,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -5322,7 +5322,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -5477,7 +5477,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5494,7 +5494,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -5625,7 +5625,7 @@
       }
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -5925,7 +5925,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -6066,7 +6066,7 @@
       }
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -6209,7 +6209,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -6338,7 +6338,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -6482,7 +6482,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -6647,7 +6647,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6664,7 +6664,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 0,
       "fillGradient": 1,
       "gridPos": {
@@ -6831,7 +6831,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 2,
       "gridPos": {
@@ -6955,7 +6955,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 0,
       "fillGradient": 1,
       "gridPos": {
@@ -7280,7 +7280,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "",
       "fill": 1,
       "fillGradient": 1,
@@ -7582,7 +7582,7 @@
     {
       "cacheTimeout": null,
       "columns": [],
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fontSize": "100%",
       "gridPos": {
         "h": 8,
@@ -7665,7 +7665,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "",
       "fill": 1,
       "fillGradient": 0,
@@ -7844,7 +7844,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -7990,7 +7990,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -8150,7 +8150,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -8296,7 +8296,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -8436,7 +8436,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -8576,7 +8576,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -8713,7 +8713,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -8730,7 +8730,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "",
       "fill": 1,
       "fillGradient": 1,
@@ -8861,7 +8861,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "Selects mean of each unique storage, sums up to total per site",
       "fill": 1,
       "fillGradient": 1,
@@ -9044,7 +9044,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -9183,7 +9183,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -9315,7 +9315,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 1,
@@ -9506,7 +9506,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -9715,7 +9715,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -9728,7 +9728,7 @@
       "type": "row"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -9892,7 +9892,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -10076,7 +10076,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -10285,7 +10285,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -10361,7 +10361,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -10579,7 +10579,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -10724,7 +10724,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -10840,7 +10840,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -10962,7 +10962,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -11077,7 +11077,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -11165,7 +11165,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "description": "",
       "fill": 1,
       "fillGradient": 1,
@@ -11412,7 +11412,7 @@
       }
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 8,
         "w": 5,
@@ -11447,7 +11447,7 @@
       "type": "alertlist"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 16,
         "w": 5,
@@ -11626,7 +11626,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -11904,7 +11904,7 @@
       }
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -11964,7 +11964,7 @@
       "type": "logs"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -12024,7 +12024,7 @@
       "type": "logs"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -12084,7 +12084,7 @@
       "type": "logs"
     },
     {
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -12222,7 +12222,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -12350,7 +12350,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -12639,7 +12639,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -12767,7 +12767,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -12906,7 +12906,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
+      "datasource": "${DS_DATASOURCE}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -13034,7 +13034,7 @@
   "schemaVersion": 30,
   "style": "dark",
   "tags": [
-    "scaleVM10v2 external",
+    "${DS_DATASOURCE}",
     "14_days",
     "v1.0.2"
   ],
@@ -13058,7 +13058,7 @@
     ]
   },
   "timezone": "",
-  "title": "SPPMON for IBM Spectrum Protect Plus scaleVM10v2 external",
-  "uid": "RMnql047z",
+  "title": "SPPMON for IBM Spectrum Protect Plus ${DS_DATASOURCE}",
+  "uid": "sppmon_single_view_DS_${DS_DATASOURCE}",
   "version": 1
 }

--- a/Grafana/SPPMON for IBM Spectrum Protect Plus.json
+++ b/Grafana/SPPMON for IBM Spectrum Protect Plus.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_DATASOURCE",
-      "label": "Datasource",
+      "name": "DS_SCALEVM10V2_EXTERNAL",
+      "label": "scaleVM10v2 external",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -32,7 +32,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "8.1.2"
+      "version": "8.1.1"
     },
     {
       "type": "panel",
@@ -143,7 +143,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -156,7 +156,7 @@
       "type": "row"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "95% Percentille over last 24h ",
       "fieldConfig": {
         "defaults": {
@@ -207,7 +207,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "groupBy": [
@@ -248,7 +248,7 @@
       "type": "gauge"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "95% Percentille over last 24h ",
       "fieldConfig": {
         "defaults": {
@@ -298,7 +298,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "",
@@ -341,7 +341,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "95% Percentille / last 24h of each component memory usage\nMax root storage usage  / last 24h of Server and vSnap",
       "fieldConfig": {
         "defaults": {
@@ -391,7 +391,7 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "$tag_name",
@@ -495,7 +495,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "Duration of the last execution of selected jobs",
       "fieldConfig": {
         "defaults": {
@@ -555,7 +555,7 @@
         "text": {},
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "$tag_jobName",
@@ -614,7 +614,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 1,
       "description": "",
       "fill": 1,
@@ -647,7 +647,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -781,7 +781,7 @@
       }
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -821,7 +821,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "groupBy": [],
@@ -861,7 +861,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -901,7 +901,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "groupBy": [],
@@ -941,7 +941,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -981,7 +981,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "groupBy": [],
@@ -1033,7 +1033,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -1073,7 +1073,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "groupBy": [],
@@ -1113,7 +1113,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -1164,7 +1164,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "$tag_ssh_type",
@@ -1224,7 +1224,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 7,
         "w": 4,
@@ -1250,7 +1250,7 @@
         },
         "tags": []
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "repeatDirection": "h",
       "timeFrom": null,
       "timeShift": null,
@@ -1258,7 +1258,7 @@
       "type": "alertlist"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "This panel shows how much the dela did increase, leaving out going down again.\nGood for noticing errors, even if they disappeared",
       "fieldConfig": {
         "defaults": {
@@ -1303,7 +1303,7 @@
         "showThresholdMarkers": false,
         "text": {}
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "--constant",
@@ -1489,7 +1489,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1542,7 +1542,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "Catalog Backup",
@@ -1577,7 +1577,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "90% percentille of last 24h per Commandgroup",
       "fieldConfig": {
         "defaults": {
@@ -1628,7 +1628,7 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "$tag_COMMAND",
@@ -1685,7 +1685,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "90% percentille of last 24h",
       "fieldConfig": {
         "defaults": {
@@ -1736,7 +1736,7 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "$tag_COMMAND",
@@ -1794,7 +1794,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "Sum of replicated bytes (VM) within the last 24h\nSum of transferred bytes (VM) within the last 24h\nSum of transferred bytes (Office365) within the last 24h\n",
       "fieldConfig": {
         "defaults": {
@@ -1838,7 +1838,7 @@
         "text": {},
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "VM Replicated",
@@ -1946,7 +1946,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -1985,7 +1985,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "groupBy": [],
@@ -2058,7 +2058,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2103,7 +2103,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "alias": "",
@@ -2144,7 +2144,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2221,7 +2221,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 1,
@@ -2252,7 +2252,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2440,7 +2440,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 1,
       "description": "Selected Processes monitored by top command\n\"java\", \"mongo\", \"beam.smp\".\nQuerie calcualted due an inner querie to filter out the PID. Simple \"mean\" would result in a falsly low result",
       "fill": 1,
@@ -2475,7 +2475,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2631,7 +2631,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 1,
@@ -2661,7 +2661,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2828,7 +2828,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -2855,7 +2855,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -3033,7 +3033,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 1,
       "description": "Mean-Sum of process-group displayed",
       "fill": 1,
@@ -3066,7 +3066,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -3187,7 +3187,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 1,
       "description": "Selected Processes monitored by top command\n\"java\", \"mongo\", \"beam.smp\"",
       "fill": 1,
@@ -3222,7 +3222,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -3364,7 +3364,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3392,7 +3392,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3538,7 +3538,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 0,
       "description": "",
       "fill": 1,
@@ -3569,7 +3569,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3704,7 +3704,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3731,7 +3731,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3876,7 +3876,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3893,7 +3893,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -3923,7 +3923,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4065,7 +4065,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4092,7 +4092,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4255,7 +4255,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4282,7 +4282,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4432,7 +4432,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4459,7 +4459,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4609,7 +4609,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4636,7 +4636,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4787,7 +4787,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4814,7 +4814,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4947,7 +4947,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4974,7 +4974,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -5133,7 +5133,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -5160,7 +5160,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -5322,7 +5322,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -5349,7 +5349,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -5477,7 +5477,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5494,7 +5494,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -5523,7 +5523,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -5625,7 +5625,7 @@
       }
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -5756,7 +5756,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "groupBy": [
@@ -5925,7 +5925,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -5954,7 +5954,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -6066,7 +6066,7 @@
       }
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -6117,7 +6117,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "groupBy": [
@@ -6209,7 +6209,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -6236,7 +6236,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -6338,7 +6338,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -6368,7 +6368,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -6482,7 +6482,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -6511,7 +6511,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -6647,7 +6647,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6664,7 +6664,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 0,
       "fillGradient": 1,
       "gridPos": {
@@ -6691,7 +6691,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -6831,7 +6831,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 2,
       "gridPos": {
@@ -6858,7 +6858,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -6955,7 +6955,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 0,
       "fillGradient": 1,
       "gridPos": {
@@ -6982,7 +6982,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -7280,7 +7280,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "",
       "fill": 1,
       "fillGradient": 1,
@@ -7310,7 +7310,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -7582,7 +7582,7 @@
     {
       "cacheTimeout": null,
       "columns": [],
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fontSize": "100%",
       "gridPos": {
         "h": 8,
@@ -7665,7 +7665,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "",
       "fill": 1,
       "fillGradient": 0,
@@ -7693,7 +7693,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -7844,7 +7844,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -7871,7 +7871,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -7990,7 +7990,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -8017,7 +8017,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -8150,7 +8150,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -8177,7 +8177,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -8296,7 +8296,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -8323,7 +8323,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -8436,7 +8436,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -8463,7 +8463,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -8576,7 +8576,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -8603,7 +8603,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -8713,7 +8713,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -8730,7 +8730,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "",
       "fill": 1,
       "fillGradient": 1,
@@ -8759,7 +8759,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -8861,7 +8861,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "Selects mean of each unique storage, sums up to total per site",
       "fill": 1,
       "fillGradient": 1,
@@ -8890,7 +8890,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -9044,7 +9044,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -9072,7 +9072,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -9183,7 +9183,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -9211,7 +9211,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -9315,7 +9315,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 1,
@@ -9346,7 +9346,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -9506,7 +9506,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -9533,7 +9533,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -9715,7 +9715,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -9728,7 +9728,7 @@
       "type": "row"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -9743,28 +9743,11 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "vadpName"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 270
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -9782,7 +9765,7 @@
           }
         ]
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "groupBy": [
@@ -9794,7 +9777,7 @@
             }
           ],
           "measurement": "vadps",
-          "orderByTime": "DESC",
+          "orderByTime": "ASC",
           "policy": "rp_half_year",
           "refId": "A",
           "resultFormat": "table",
@@ -9802,17 +9785,25 @@
             [
               {
                 "params": [
-                  "state"
+                  "vadpId"
                 ],
                 "type": "field"
               },
               {
                 "params": [],
                 "type": "last"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "status"
+                ],
+                "type": "field"
               },
               {
                 "params": [
-                  "State"
+                  "Status"
                 ],
                 "type": "alias"
               }
@@ -9852,6 +9843,48 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "VADP Proxy State",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": ""
+                  }
+                },
+                "fieldName": "vadpName"
+              },
+              {
+                "config": {
+                  "id": "isNull",
+                  "options": {}
+                },
+                "fieldName": "Status"
+              }
+            ],
+            "match": "all",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "VADP-ID": true,
+              "last": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Status": "Last State",
+              "Time": "",
+              "vadpName": "Name of VADP"
+            }
+          }
+        }
+      ],
       "type": "table"
     },
     {
@@ -9859,7 +9892,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -9886,7 +9919,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -9902,11 +9935,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "$tag_siteName Enabled",
+          "alias": "$tag_siteName $tag_state",
           "groupBy": [
             {
               "params": [
                 "siteName"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "status"
               ],
               "type": "tag"
             }
@@ -9920,35 +9959,7 @@
             [
               {
                 "params": [
-                  "enabled_count"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "$tag_siteName Disabled",
-          "groupBy": [
-            {
-              "params": [
-                "siteName"
-              ],
-              "type": "tag"
-            }
-          ],
-          "hide": true,
-          "measurement": "vadps",
-          "orderByTime": "ASC",
-          "policy": "rp_days_14",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "disabled_count"
+                  "count"
                 ],
                 "type": "field"
               }
@@ -10065,7 +10076,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -10092,7 +10103,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -10274,7 +10285,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -10350,7 +10361,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -10377,7 +10388,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -10568,7 +10579,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -10596,7 +10607,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -10713,7 +10724,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -10741,7 +10752,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -10829,7 +10840,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -10857,7 +10868,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -10951,7 +10962,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -10981,7 +10992,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -11066,7 +11077,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -11125,7 +11136,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "panelId": 142,
@@ -11154,7 +11165,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "description": "",
       "fill": 1,
       "fillGradient": 1,
@@ -11183,7 +11194,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 0.5,
       "points": true,
       "renderer": "flot",
@@ -11401,7 +11412,7 @@
       }
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 8,
         "w": 5,
@@ -11427,7 +11438,7 @@
         },
         "tags": []
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "repeat": null,
       "repeatDirection": "h",
       "timeFrom": null,
@@ -11436,7 +11447,7 @@
       "type": "alertlist"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 16,
         "w": 5,
@@ -11462,7 +11473,7 @@
         },
         "tags": []
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "repeatDirection": "h",
       "timeFrom": null,
       "timeShift": null,
@@ -11615,7 +11626,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "decimals": 0,
       "fill": 1,
       "fillGradient": 1,
@@ -11645,7 +11656,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -11893,7 +11904,7 @@
       }
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -11953,7 +11964,7 @@
       "type": "logs"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -12013,7 +12024,7 @@
       "type": "logs"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -12073,7 +12084,7 @@
       "type": "logs"
     },
     {
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -12105,7 +12116,7 @@
       "options": {
         "showHeader": true
       },
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "targets": [
         {
           "groupBy": [
@@ -12211,7 +12222,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -12339,7 +12350,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -12366,7 +12377,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -12628,7 +12639,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -12655,7 +12666,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -12756,7 +12767,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -12785,7 +12796,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -12895,7 +12906,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_DATASOURCE}",
+      "datasource": "${DS_SCALEVM10V2_EXTERNAL}",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -12922,7 +12933,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.2",
+      "pluginVersion": "8.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -13023,9 +13034,9 @@
   "schemaVersion": 30,
   "style": "dark",
   "tags": [
-    "v1.0",
-    "${DS_DATASOURCE}",
-    "14_days"
+    "scaleVM10v2 external",
+    "14_days",
+    "v1.0.2"
   ],
   "templating": {
     "list": []
@@ -13047,7 +13058,7 @@
     ]
   },
   "timezone": "",
-  "title": "SPPMON for IBM Spectrum Protect Plus ${DS_DATASOURCE}",
-  "uid": "sppmon_single_view_DS_${DS_DATASOURCE}",
-  "version": 5
+  "title": "SPPMON for IBM Spectrum Protect Plus scaleVM10v2 external",
+  "uid": "RMnql047z",
+  "version": 1
 }

--- a/python/influx/definitions.py
+++ b/python/influx/definitions.py
@@ -731,11 +731,13 @@ class Definitions:
                 'vadpName':         Datatype.STRING,
                 'vadpId':           Datatype.INT,
                 'ipAddr':           Datatype.STRING,
+                'isEnabled':        Datatype.INT
             },
             tags=[
                 'siteId',
                 'siteName',
-                'version'
+                'version',
+                'name'
             ],
             retention_policy=cls._RP_HALF_YEAR(),
             continuous_queries=[

--- a/python/influx/definitions.py
+++ b/python/influx/definitions.py
@@ -1,4 +1,4 @@
-"""All kinds of table, retention policies and continuous queries definitions are implemented here
+"""All kinds of tables, retention policies and continuous queries definitions are implemented here
 
 Classes:
     Definitions
@@ -12,15 +12,15 @@ from influx.influx_queries import ContinuousQuery, Keyword, SelectionQuery
 
 
 class Definitions:
-    """Within this class all tables, retention policies and continuous queries are defined.
+    """Within this class, all tables, retention policies, and continuous queries are defined.
 
     Use each area to declare each type.
-    Retention Policices are *always* declared at top AS classmethod.
+    Retention Policies are *always* declared at the top as classmethod.
     You may use individual CQ below with the table declaration or define a template below the RP's.
-    See existent definitions to declare you own.
+    See existent definitions to declare your own.
 
-    Start of all execution is the single method `add_table_definitions`.
-    Do NOT use anything before executin this, the ClassVar `database` is set in there.
+    The start of all execution is the single method `add_table_definitions`.
+    Do NOT use anything before executing this, the ClassVar `database` is set in there.
 
     Attributes:
         __database
@@ -43,11 +43,11 @@ class Definitions:
 
     # ################ Retention Policies ##################
     # ################       README       ##################
-    # Be aware data is stored by either the duration or the longest CQ-GROUP BY time accessing the data
-    # Grouped into grafana-dashboards of either 14, 90 or INF Days. Select duration accordingly.
+    # Be aware data is stored by either its duration or the longest CQ-GROUP BY clause duration.
+    # Grouped into grafana-dashboards of either 14, 90, or INF Days. Select duration accordingly.
     # High Data count is stored in 14d, downsampled to 90d (1d), then to INF (1w).
     # Low Data count is stored in 90d, downsampled to INF (1w).
-    # Data which cannot be downsampled is preserved for either half or full year.
+    # Data that cannot be downsampled is preserved for either half or full year.
 
     @classmethod
     def _RP_AUTOGEN(cls):
@@ -94,11 +94,12 @@ class Definitions:
     @classmethod
     def _CQ_DWSMPL(
             cls, fields: List[str], new_retention_policy: RetentionPolicy,
-            group_time: str, group_args: List[str] = None) -> Callable[[Table, str], ContinuousQuery]:
+            group_time: str, group_args: List[str] = ["*"]) -> Callable[[Table, str], ContinuousQuery]:
         """Creates a template CQ which groups by time, * . Always uses the base table it was created from.
 
-        The callable shall aways have this format, the missing fields are filled by the `__add_table_def`-method.
-        The need of this is that no table-instance is available, since CQ are defined together with the table.
+            Downsamples the data into another retention policy, using given aggregations within the list of fields.
+            It is required to return a callable since at the time of declaration no table instance is available.
+            The tables are inserted at runtime within the setup of the influx-client.
 
         Args:
             fields (List[str]): Fields to be selected and aggregated, influx-keywords need to be escaped.
@@ -109,7 +110,7 @@ class Definitions:
         Returns:
             Callable[[Table, str], ContinuousQuery]: Lambda which is transformed into a CQ later on.
         """
-        if(not group_args):
+        if(group_args is None):
             group_args = ["*"]
         return lambda table, name: ContinuousQuery(
             name=name, database=cls.__database,
@@ -122,34 +123,14 @@ class Definitions:
             for_interval="1w"
         )
 
-    # @classmethod
-    # def _CQ_TRNSF(cls, new_retention_policy: RetentionPolicy) -> Callable[[Table, str], ContinuousQuery]:
-    #     """Creates a CQ to transfer data into a different Retention Policy.
-    #     TODO BUGGED, does not work without grouped by time()
-
-    #     Args:
-    #         new_retention_policy (RetentionPolicy): [description]
-
-    #     Returns:
-    #         Callable[[Table, str], ContinuousQuery]: [description]
-    #     """
-    #     return lambda table, name: ContinuousQuery(
-    #         name=name, database=cls.__database,
-    #         select_query=SelectionQuery(
-    #             Keyword.SELECT,
-    #             tables=[table],
-    #             into_table=Table(cls.__database, table.name, retention_policy=new_retention_policy),
-    #             fields=["*"],
-    #             group_list=["*"]),
-    #         every_interval="1m",
-    #         for_interval="1w"
-    #     )
-
     @classmethod
     def _CQ_TMPL(
             cls, fields: List[str], new_retention_policy: RetentionPolicy,
             group_time: str, group_args: List[str] = ["*"], where_str: str = None) -> Callable[[Table, str], ContinuousQuery]:
         """Creates a CQ to do whatever you want with it.
+
+        It is required to return a callable since at the time of declaration no table instance is available.
+        The tables are inserted at runtime within the setup of the influx-client.
 
         Args:
             fields (List[str]): Fields to be selected and aggregated, influx-keywords need to be escaped.
@@ -161,7 +142,7 @@ class Definitions:
         Returns:
             Callable[[Table, str], ContinuousQuery]: Lambda which is transformed into a CQ later on.
         """
-        if(not group_args):
+        if(group_args is None):
             group_args = ["*"]
         return lambda table, name: ContinuousQuery(
             name=name, database=cls.__database,

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -66,6 +66,7 @@ Author:
  08/25/2021 version 0.15.1 Replaced SLA-Endpoint by so-far unknown endpoint, bringing it in line with other api-requests.
  08/27/2021 version 1.0.0  Release of SPPMon
  08/27/2021 version 1.0.1  Reverted parts of the SLA-Endpoint change
+ 08/31/2021 version 1.0.2  Changed VADP table definition to prevent drop of false duplicates
 """
 from __future__ import annotations
 
@@ -94,7 +95,7 @@ from utils.methods_utils import MethodUtils
 from utils.spp_utils import SppUtils
 
 # Version:
-VERSION = "1.0.1  (2021/08/27)"
+VERSION = "1.0.2  (2021/08/31)"
 
 
 # ----------------------------------------------------------------------------

--- a/python/sppmonMethods/protection.py
+++ b/python/sppmonMethods/protection.py
@@ -97,17 +97,13 @@ class ProtectionMethods:
             source_func=self.__api_queries.get_vadps,
             rename_tuples=[
                 ('id', 'vadpId'),
-                ('displayName', 'vadpName')
+                ('displayName', 'vadpName'),
+                ("state", "status")
             ],
             deactivate_verbose=True
             )
         for row in result:
             row['siteName'] = self.__system_methods.site_name_by_id(row['siteId'])
-            row['name'] = row['vadpName']
-            if (row['state'] == "ENABLED"):
-                row['isEnabled'] = 1
-            else:
-                row['isEnabled'] = 0
         if(self.__verbose):
             MethodUtils.my_print(result)
 

--- a/python/sppmonMethods/protection.py
+++ b/python/sppmonMethods/protection.py
@@ -121,6 +121,11 @@ class ProtectionMethods:
             )
         for row in result:
             row['siteName'] = self.__system_methods.site_name_by_id(row['siteId'])
+            row['name'] = row['vadpName']
+            if (row['state'] == "ENABLED"):
+                row['isEnabled'] = 1
+            else:
+                row['isEnabled'] = 0
         if(self.__verbose):
             MethodUtils.my_print(result)
 

--- a/python/sppmonMethods/system.py
+++ b/python/sppmonMethods/system.py
@@ -47,6 +47,9 @@ class SystemMethods:
             source_func=self.__api_queries.get_file_system,
             deactivate_verbose=True
         )
+
+        # This is not a key value, but a value rename
+        # Therefore the regular rename-tuples do not work.
         value_renames = {
             'Configuration':            "Configuration",
             'Search':                   "File",


### PR DESCRIPTION
### Changed

* Marked the default group time when using the template CQ more clearly as `[*]`
* Grafana Dashboards:
  * 14-Day dashboard:
    * Changed VADP Proxy state table to support the VADPName grouping and status
      * Used Grafana organizing mechanics to leave query intact, hiding old data with status=null and vadpName="".
    * Changed VADP Proxy state per site to only use new data since 14-day is not too long
      * Changed to use field count and group over status instead of two separate queries
  * 90-Day dashboard:
    * Changed %-Enabled VADP dashboard to total count dashboard
    * Added for both VADP Proxy state and total count dashboard a new query, grouping over status and grouping on `count`. Old queries left intact for backward compatibility.
    * Hides series with null/none, adding average to legend.

* InfluxDB-Table `VADPs`:
  * Moved fields `state` and `vadpName` to tags
    * Renamed `state` to `status` to avoid issues due to double-named tags/fields
  * Changed CQ to group only over 'old' Tags
  * Changed aggregation from a split over enabled/disable to grouping over the state itself.
    This removes now-duplicate CQ definitions and all `WHERE`-grouping clauses.

### Fixed

* VADPs are no longer dropped due to being marked as duplicates by the InfluxDB.