### PR TITLE
Rest error messages & skip client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - yyyy-mm-dd
 
-Here we write upgrading notes for brands. It's a team effort to make them as
-straightforward as possible.
+### Added
+
+### Changed
+
+### Fixed
+
+## [1.1.0] - 2021-09-09
 
 ### Added
 
@@ -21,6 +26,8 @@ straightforward as possible.
 * Adds the `skip_cmd` option to the default-config file.
 
 ### Fixed
+
+* `--test`-execution: Fixes unusual KeyError when using a config file with more than one vSnap (or other) ssh-client.
 
 ## [1.0.2] - 2021-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ straightforward as possible.
 
 ### Added
 
-* Added ConnectionUtils function `rest_response_error`. This function helps extracting the response-error message and includes all important informations into a ValueError.
+* Added ConnectionUtils function `rest_response_error`. This function helps to extract the response-error message and includes all important pieces of information into a ValueError. This error should be raised afterward.
 * Config-file option for ssh-clients `skip_cmds`. List of strings like `["mpstat", "ps"]` to skip commands on certain clients.
 
 ### Changed
 
 * REST-API Login and Statuscheck for get_objects use the new function `rest_response_error` to raise their error.
+* Adds the `skip_cmd` option to the default-config file.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ straightforward as possible.
 
 ### Added
 
+* Added ConnectionUtils function `rest_response_error`. This function helps extracting the response-error message and includes all important informations into a ValueError.
+
 ### Changed
+
+* REST-API Login and Statuscheck for get_objects use the new function `rest_response_error` to raise their error.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ straightforward as possible.
 ### Added
 
 * Added ConnectionUtils function `rest_response_error`. This function helps extracting the response-error message and includes all important informations into a ValueError.
+* Config-file option for ssh-clients `skip_cmds`. List of strings like `["mpstat", "ps"]` to skip commands on certain clients.
 
 ### Changed
 

--- a/config_files/sppconnections_default.conf
+++ b/config_files/sppconnections_default.conf
@@ -22,7 +22,8 @@
               "srv_port"    :  22,
               "username"    :  "xxx",
               "password"    :  "xxx",
-              "type"        :  "server"
+              "type"        :  "server",
+              "skip_cmds"   :  []
             },
             {
               "name"        : "sppServer/vsnap",
@@ -30,7 +31,8 @@
               "srv_port"    :  22,
               "username"    :  "xxx",
               "password"    :  "xxx",
-              "type"        :  "vsnap"
+              "type"        :  "vsnap",
+              "skip_cmds"   :  []
             },
             {
               "name"        : "otherSRV",
@@ -38,7 +40,8 @@
               "srv_port"    :  22,
               "username"    :  "xxx",
               "password"    :  "xxx",
-              "type"        :  "other"
+              "type"        :  "other",
+              "skip_cmds"   :  []
             },
             {
               "name"        : "vadp",
@@ -46,7 +49,8 @@
               "srv_port"    : 22,
               "username"    : "xxx",
               "password"    : "xxx",
-              "type"        : "vadp"
+              "type"        : "vadp",
+              "skip_cmds"   :  []
             }
     ]
 

--- a/python/sppConnection/rest_client.py
+++ b/python/sppConnection/rest_client.py
@@ -141,7 +141,7 @@ class RestClient():
             raise ValueError("error when logging out")
 
         if response_logout.status_code != 204:
-            raise ValueError("Wrong Status code when logging out", response_logout.status_code)
+            raise ConnectionUtils.rest_response_error(response_logout, "Wrong Status code when logging out")
 
         if(self.__verbose):
             LOGGER.info("Rest-API logout successfull")
@@ -427,8 +427,9 @@ class RestClient():
                 raise ValueError("error when requesting endpoint", error)
 
         if( not response_query.ok):
-            raise ValueError("Wrong Status code when requesting endpoint data",
-                             response_query.status_code, url, response_query)
+            raise ConnectionUtils.rest_response_error( response_query,
+            "Wrong Status code when requesting endpoint data",
+            url)
 
         try:
             response_json: Dict[str, Any] = response_query.json()

--- a/python/sppConnection/ssh_client.py
+++ b/python/sppConnection/ssh_client.py
@@ -114,6 +114,7 @@ class SshClient:
         host_name
         client_type
         client_name
+        skip_cmds
 
     Methods:
         execute_commands - Executes given commands on this ssh client.
@@ -128,6 +129,11 @@ class SshClient:
     def client_name(self) -> str:
         """name of the associated ssh client"""
         return self.__client_name
+
+    @property
+    def skip_cmds(self) -> List[str]:
+        "commands to be skipped with this client"
+        return self.__skip_cmds
 
     @property
     def client_type(self) -> SshTypes:
@@ -145,6 +151,7 @@ class SshClient:
         self.__user_name: str = auth_ssh["username"]
         self.__password: str = auth_ssh["password"]
         self.__client_name: str = auth_ssh["name"]
+        self.__skip_cmds: List[str] = auth_ssh.get("skip_cmds", []) # optional
         try:
             self.__client_type = SshTypes(auth_ssh["type"].upper())
         except KeyError:
@@ -213,6 +220,10 @@ class SshClient:
         new_command_list: List[SshCommand] = []
         for ssh_command in commands:
 
+            if(self.__skip_cmd(ssh_command)):
+                LOGGER.info(f"Skipped command {ssh_command.cmd} on host {self.host_name}")
+                continue
+
             try:
                 LOGGER.debug(f"Executing command {ssh_command.cmd} on host {self.host_name}")
                 result = self.__send_command(ssh_command.cmd)
@@ -233,6 +244,19 @@ class SshClient:
 
         return new_command_list
 
+    def __skip_cmd(self, ssh_command: SshCommand) -> bool:
+        """Checks if the given SshCommand is within the list of commands to be skipped
+
+        Args:
+            ssh_command (SshCommand): Current SshCommand to be checked
+
+        Returns:
+            bool: True: Should be skipped, False: Should not be skipped
+        """
+        for skip_cmd in self.skip_cmds:
+            if (skip_cmd in ssh_command.cmd):
+                return True
+        return False
 
     def __send_command(self, ssh_command: str) ->  str:
         """Sends a command to the ssh client. Raises error if fails.

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -67,6 +67,7 @@ Author:
  08/27/2021 version 1.0.0  Release of SPPMon
  08/27/2021 version 1.0.1  Reverted parts of the SLA-Endpoint change
  08/31/2021 version 1.0.2  Changed VADP table definition to prevent drop of false duplicates
+ 08/31/2021 version 1.0.3  Increase logging for REST-API errors.
 """
 from __future__ import annotations
 
@@ -95,7 +96,7 @@ from utils.methods_utils import MethodUtils
 from utils.spp_utils import SppUtils
 
 # Version:
-VERSION = "1.0.2  (2021/08/31)"
+VERSION = "1.0.3  (2021/08/31)"
 
 
 # ----------------------------------------------------------------------------

--- a/python/sppmon.py
+++ b/python/sppmon.py
@@ -67,7 +67,7 @@ Author:
  08/27/2021 version 1.0.0  Release of SPPMon
  08/27/2021 version 1.0.1  Reverted parts of the SLA-Endpoint change
  08/31/2021 version 1.0.2  Changed VADP table definition to prevent drop of false duplicates
- 08/31/2021 version 1.0.3  Increase logging for REST-API errors.
+ 09/09/2021 version 1.1.0  Increase logging for REST-API errors, add ssh-client skip option for cfg file.
 """
 from __future__ import annotations
 
@@ -96,7 +96,7 @@ from utils.methods_utils import MethodUtils
 from utils.spp_utils import SppUtils
 
 # Version:
-VERSION = "1.0.3  (2021/08/31)"
+VERSION = "1.1.0  (2021/09/09)"
 
 
 # ----------------------------------------------------------------------------

--- a/python/sppmonMethods/testing.py
+++ b/python/sppmonMethods/testing.py
@@ -189,7 +189,8 @@ class TestingMethods():
         # Check total missing clients
         missing_types: Set[SshTypes] = set(SshTypes)
         for client in ssh_clients:
-            missing_types.remove(client.client_type)
+            if(client.client_type in missing_types):
+                missing_types.remove(client.client_type)
         if(missing_types):
             warnings.append(
                 f"""This is only a reminder: No ssh-clients of following types are registered: {", ".join(map(str, missing_types))}""")
@@ -392,7 +393,7 @@ class TestingMethods():
 
         # ## InfluxDB ##
         try:
-            influx_errors, influx_warnings = cls.__test_influx(influx_client)
+            influx_errors, influx_warnings = ([],[]) # cls.__test_influx(influx_client)
         except ValueError as error:
             ExceptionUtils.exception_info(
                 error, extra_message="> Testing of the InfluxDB failed due an unknown error")
@@ -407,7 +408,7 @@ class TestingMethods():
         # ## REST-API ##
 
         try:
-            rest_errors, rest_warnings = cls.__test_REST_API(rest_client)
+            rest_errors, rest_warnings = ([],[]) #cls.__test_REST_API(rest_client)
         except ValueError as error:
             ExceptionUtils.exception_info(
                 error, extra_message="> Testing of the REST-API failed due an unknown error")

--- a/python/sppmonMethods/testing.py
+++ b/python/sppmonMethods/testing.py
@@ -393,7 +393,7 @@ class TestingMethods():
 
         # ## InfluxDB ##
         try:
-            influx_errors, influx_warnings = ([],[]) # cls.__test_influx(influx_client)
+            influx_errors, influx_warnings = cls.__test_influx(influx_client)
         except ValueError as error:
             ExceptionUtils.exception_info(
                 error, extra_message="> Testing of the InfluxDB failed due an unknown error")
@@ -408,7 +408,7 @@ class TestingMethods():
         # ## REST-API ##
 
         try:
-            rest_errors, rest_warnings = ([],[]) #cls.__test_REST_API(rest_client)
+            rest_errors, rest_warnings = cls.__test_REST_API(rest_client)
         except ValueError as error:
             ExceptionUtils.exception_info(
                 error, extra_message="> Testing of the REST-API failed due an unknown error")

--- a/python/utils/connection_utils.py
+++ b/python/utils/connection_utils.py
@@ -292,8 +292,8 @@ class ConnectionUtils:
         """
 
         full_error_text = response.text
-        match = re.match(r".*?<title>(.*?)<\/title>.*", full_error_text)
-        if(match):
-            full_error_text = match.group(1)
+        #match = re.match(r".*?<title>(.*?)<\/title>.*", full_error_text)
+        #if(match):
+        #    full_error_text = match.group(1)
 
         return ValueError(message, response.status_code, response.reason, full_error_text, args)

--- a/python/utils/connection_utils.py
+++ b/python/utils/connection_utils.py
@@ -292,8 +292,8 @@ class ConnectionUtils:
         """
 
         full_error_text = response.text
-        #match = re.match(r".*?<title>(.*?)<\/title>.*", full_error_text)
-        #if(match):
-        #    full_error_text = match.group(1)
+        match = re.match(r".*?<title>(.*?)<\/title>.*", full_error_text)
+        if(match):
+            full_error_text = match.group(1)
 
         return ValueError(message, response.status_code, response.reason, full_error_text, args)


### PR DESCRIPTION
* Added ConnectionUtils function `rest_response_error`. This function helps extracting the response-error message and includes all important informations into a ValueError.
* Config-file option for ssh-clients `skip_cmds`. List of strings like `["mpstat", "ps"]` to skip commands on certain clients.

### Changed

* REST-API Login and Statuscheck for get_objects use the new function `rest_response_error` to raise their error.
