### PR TITLE
fixing issue #86 by adding a systemctl status check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
 ## [Unreleased] - yyyy-mm-dd
 
 ### Added
 
-* Adds FullLogs and LoadedSystem information to the Grafana SPPMon Runtime Duration panel. 
-
 ### Changed
 
 ### Fixed
+
+## [1.1.1] - 2022-02-22
+
+### Added
+
+* Adds FullLogs and LoadedSystem information to the Grafana SPPMon Runtime Duration panel. 
+* Adds license information into each SPPMon code file.
+* Specifies the encoding and reading permission when opening config files.
+
+### Changed
+
+* Avoids the wget-certificate check when installing and downloading the python tgz in the installer.
+* Updates the requirements.txt to include sub-dependencies and updates to lates version.
+
+### Fixed
+
+* Fixes Issue #86 vSnap hanging up on start due to pool call by checking first if the `vsnap` command is available.
 
 ## [1.1.0] - 2021-09-09
 

--- a/python/sppmonMethods/ssh.py
+++ b/python/sppmonMethods/ssh.py
@@ -125,12 +125,12 @@ class SshMethods:
             # VSnap
             SshTypes.VSNAP:[
                 SshCommand(
-                    command='sudo vsnap --json pool show',
+                    command='systemctl status vsnap-api.service > /dev/null && sudo vsnap --json pool show',
                     parse_function=SshMethods._parse_pool_show_cmd,
                     table_name="vsnap_pools"
                 ),
                 SshCommand(
-                    command='sudo vsnap --json system stats',
+                    command='systemctl status vsnap-api.service > /dev/null && sudo vsnap --json system stats',
                     parse_function=SshMethods._parse_system_stats_cmd,
                     table_name="vsnap_system_stats"
                 ),


### PR DESCRIPTION
* Fixes issue #86 by adding a simple systemctl status check, preventing any `vsnap` commands before the service is up.